### PR TITLE
MAINT-26765 Avoid parsing request parameters only when migration is still in progress

### DIFF
--- a/data-upgrade-portal-rdbms/src/main/java/org/exoplatform/portal/jdbc/migration/MigrationFilter.java
+++ b/data-upgrade-portal-rdbms/src/main/java/org/exoplatform/portal/jdbc/migration/MigrationFilter.java
@@ -28,7 +28,7 @@ public class MigrationFilter implements Filter {
 
   @Override
   public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
-    if (!(request instanceof HttpServletRequest)) {
+    if (!(request instanceof HttpServletRequest) || MigrationContext.isDone()) {
       chain.doFilter(request, response);
       return;
     }


### PR DESCRIPTION
The HTTP Input Stream could be read only once, thus, parsing the request parameters in a filter should be done only in special cases (When calling HTTPServletRequest.getParameterMap the method HTTPservletRequest.getInputStream will always return empty stream). A condition has been added to avoid calling the method HTTPServletRequest.getParameterMap only when needed