### PR TITLE
MAINT-2799: Add news upgrade plugin in order to remove administrators permission from each space News jcr node

### DIFF
--- a/data-upgrade-news/pom.xml
+++ b/data-upgrade-news/pom.xml
@@ -1,0 +1,44 @@
+<!-- Copyright (C) 2009 eXo Platform SAS. This is free software; you can 
+  redistribute it and/or modify it under the terms of the GNU Lesser General 
+  Public License as published by the Free Software Foundation; either version 
+  2.1 of the License, or (at your option) any later version. This software 
+  is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; 
+  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR 
+  PURPOSE. See the GNU Lesser General Public License for more details. You 
+  should have received a copy of the GNU Lesser General Public License along 
+  with this software; if not, write to the Free Software Foundation, Inc., 
+  51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA, or see the FSF site: 
+  http://www.fsf.org. -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.exoplatform.addons.upgrade</groupId>
+    <artifactId>upgrade</artifactId>
+    <version>6.0.x-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>data-upgrade-news</artifactId>
+  <packaging>jar</packaging>
+  <name>eXo Add-on:: Data Upgrade Add-on - NEWS</name>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.exoplatform.commons</groupId>
+      <artifactId>commons-component-upgrade</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.exoplatform.jcr</groupId>
+      <artifactId>exo.jcr.component.ext</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.exoplatform.ecms</groupId>
+      <artifactId>ecms-core-services</artifactId>
+      <scope>provided</scope>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/data-upgrade-news/src/main/java/org/exoplatform/news/upgrade/jcr/NewsJcrNodePermissionsUpgradePlugin.java
+++ b/data-upgrade-news/src/main/java/org/exoplatform/news/upgrade/jcr/NewsJcrNodePermissionsUpgradePlugin.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (C) 2003-2020 eXo Platform SAS.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.exoplatform.news.upgrade.jcr;
+
+import javax.jcr.Node;
+import javax.jcr.NodeIterator;
+import javax.jcr.Session;
+
+import org.exoplatform.commons.api.settings.SettingService;
+import org.exoplatform.commons.upgrade.UpgradeProductPlugin;
+import org.exoplatform.container.xml.InitParams;
+import org.exoplatform.services.cms.BasePath;
+import org.exoplatform.services.jcr.RepositoryService;
+import org.exoplatform.services.jcr.core.ExtendedNode;
+import org.exoplatform.services.jcr.ext.common.SessionProvider;
+import org.exoplatform.services.jcr.ext.hierarchy.NodeHierarchyCreator;
+import org.exoplatform.services.log.ExoLogger;
+import org.exoplatform.services.log.Log;
+
+/**
+ * Created by The eXo Platform SAS Author : Ayoub Zayati Sept 14, 2020 This
+ * plugin will be executed in order to remove administrators permission from
+ * each space news folder
+ */
+public class NewsJcrNodePermissionsUpgradePlugin extends UpgradeProductPlugin {
+
+  /**
+   * @param settingService
+   * @param initParams
+   */
+  public NewsJcrNodePermissionsUpgradePlugin(SettingService settingService,
+                                             InitParams initParams,
+                                             NodeHierarchyCreator nodeHierarchyCreator,
+                                             RepositoryService repositoryService) {
+    super(settingService, initParams);
+    this.nodeHierarchyCreator_ = nodeHierarchyCreator;
+    this.repositoryService_ = repositoryService;
+  }
+
+  private static final Log     log               = ExoLogger.getLogger(NewsJcrNodePermissionsUpgradePlugin.class.getName());
+
+  private NodeHierarchyCreator nodeHierarchyCreator_;
+
+  private RepositoryService    repositoryService_;
+
+  private static final String  NEWS_NODES_FOLDER = "News";
+
+  private static final String  NEWS_WORKSPACE    = "collaboration";
+
+  @Override
+  public void processUpgrade(String oldVersion, String newVersion) {
+    if (log.isInfoEnabled()) {
+      log.info("Start " + this.getClass().getName() + ".............");
+    }
+    SessionProvider sessionProvider = null;
+    try {
+      sessionProvider = SessionProvider.createSystemProvider();
+      Session session = sessionProvider.getSession(NEWS_WORKSPACE, repositoryService_.getCurrentRepository());
+
+      String spacesNodePath = nodeHierarchyCreator_.getJcrPath(BasePath.CMS_GROUPS_PATH) + "/spaces";
+      Node spacesRootNode = (Node) session.getItem(spacesNodePath);
+      NodeIterator iter = spacesRootNode.getNodes();
+      while (iter.hasNext()) {
+        Node spaceNode = iter.nextNode();
+        if (spaceNode.hasNode(NEWS_NODES_FOLDER)) {
+          Node spaceNewsRootNode = spaceNode.getNode(NEWS_NODES_FOLDER);
+          ((ExtendedNode) spaceNewsRootNode).removePermission("*:/platform/administrators");
+          spaceNewsRootNode.save();
+        }
+      }
+    } catch (Exception e) {
+      if (log.isErrorEnabled()) {
+        log.error("An unexpected error occurs when migrating news jcr node permissions:", e);
+      }
+    } finally {
+      if (sessionProvider != null) {
+        sessionProvider.close();
+      }
+    }
+  }
+}

--- a/data-upgrade-news/src/main/resources/conf/portal/configuration.xml
+++ b/data-upgrade-news/src/main/resources/conf/portal/configuration.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Copyright (C) 2003-2011 eXo Platform SAS. This program is free software: 
+  you can redistribute it and/or modify it under the terms of the GNU Affero 
+  General Public License as published by the Free Software Foundation, either 
+  version 3 of the License, or (at your option) any later version. This program 
+  is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; 
+  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR 
+  PURPOSE. See the GNU Affero General Public License for more details. You 
+  should have received a copy of the GNU Affero General Public License along 
+  with this program. If not, see <http://www.gnu.org/licenses/>. -->
+
+<configuration xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.exoplatform.org/xml/ns/kernel_1_2.xsd http://www.exoplatform.org/xml/ns/kernel_1_2.xsd"
+  xmlns="http://www.exoplatform.org/xml/ns/kernel_1_2.xsd">
+
+  <external-component-plugins>
+    <target-component>org.exoplatform.commons.upgrade.UpgradeProductService</target-component>
+    <component-plugin profiles="news">
+      <name>NewsJcrNodePermissionsUpgradePlugin</name>
+      <set-method>addUpgradePlugin</set-method>
+      <type>org.exoplatform.news.upgrade.jcr.NewsJcrNodePermissionsUpgradePlugin</type>
+      <description>Remove administrators permission from each space news folder</description>
+      <init-params>
+        <value-param>
+          <name>product.group.id</name>
+          <description>The groupId of the product</description>
+          <value>org.exoplatform.addons.news</value>
+        </value-param>
+        <value-param>
+          <name>plugin.execution.order</name>
+          <description>The plugin execution order</description>
+          <value>1</value>
+        </value-param>
+        <value-param>
+          <name>plugin.upgrade.execute.once</name>
+          <description>Execute this upgrade plugin only once</description>
+          <value>true</value>
+        </value-param>
+        <value-param>
+          <name>plugin.upgrade.target.version</name>
+          <description>Target version of the plugin</description>
+          <value>6.0.0</value>
+        </value-param>
+      </init-params>
+    </component-plugin>
+  </external-component-plugins>
+</configuration>
+

--- a/data-upgrade-packaging/pom.xml
+++ b/data-upgrade-packaging/pom.xml
@@ -56,6 +56,10 @@
       <groupId>${project.groupId}</groupId>
       <artifactId>data-upgrade-ecms</artifactId>
     </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>data-upgrade-news</artifactId>
+    </dependency>
 
     <!-- Transitive dependencies provided by eXo : set to provided -->
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -23,6 +23,7 @@
     <module>data-upgrade-portal-rdbms</module>
     <module>data-upgrade-wiki-editor</module>
     <module>data-upgrade-ecms</module>
+    <module>data-upgrade-news</module>
     <module>data-upgrade-packaging</module>
   </modules>
   <properties>
@@ -63,7 +64,6 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
-	  
       <dependency>
         <groupId>org.exoplatform.ecms</groupId>
         <artifactId>ecms</artifactId>
@@ -173,6 +173,11 @@
       <dependency>
         <groupId>${project.groupId}</groupId>
         <artifactId>data-upgrade-wiki-editor-wiki-service-xwiki</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>${project.groupId}</groupId>
+        <artifactId>data-upgrade-news</artifactId>
         <version>${project.version}</version>
       </dependency>
       <dependency>


### PR DESCRIPTION
We need to implement NewsJcrNodePermissionsUpgradePlugin in order to remove administrators permission from each already existing space News jcr node