### PR TITLE
Remove exo.core.component.jdbc dependency

### DIFF
--- a/data-upgrade-wiki-editor/wiki-service-xwiki/pom.xml
+++ b/data-upgrade-wiki-editor/wiki-service-xwiki/pom.xml
@@ -252,11 +252,6 @@
       <scope>runtime</scope>
     </dependency>
     <dependency>
-      <groupId>org.exoplatform.core</groupId>
-      <artifactId>exo.core.component.organization.jdbc</artifactId>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
       <groupId>xpp3</groupId>
       <artifactId>xpp3</artifactId>
       <scope>runtime</scope>


### PR DESCRIPTION
When removing xstream dependency, we completly remove module exo.core.component.jdbc which was deprecated
This commit remove the dependency on this module