### PR TITLE
Remove exo.core.component.jdbc dependency (#10)

### DIFF
--- a/data-upgrade-packaging/pom.xml
+++ b/data-upgrade-packaging/pom.xml
@@ -106,11 +106,6 @@
       <artifactId>xercesImpl</artifactId>
       <scope>provided</scope>
     </dependency>
-    <dependency>
-      <groupId>com.thoughtworks.xstream</groupId>
-      <artifactId>xstream</artifactId>
-      <scope>provided</scope>
-    </dependency>
 
   </dependencies>
   <build>

--- a/data-upgrade-packaging/src/main/assemblies/data-upgrade-addon-package.xml
+++ b/data-upgrade-packaging/src/main/assemblies/data-upgrade-addon-package.xml
@@ -49,8 +49,6 @@
         <exclude>org.slf4j:slf4j-logj12:*</exclude>
         <!-- We use jul-to-slf4j, thus this one is forbidden to avoid infinite loops -->
         <exclude>org.slf4j:slf4j-jdk14:*</exclude>
-        <!-- These old versions of xstream are in conflict with new ones under com.thoughtworks.xstream:xstream -->
-        <exclude>xstream:xstream:*</exclude>
         <!-- These old versions of jdom are in conflict with new ones under org.jdom -->
         <exclude>jdom:*:*</exclude>
         <!-- Servlet API are provided by the app server. It shouldn't come from a project -->

--- a/data-upgrade-wiki-editor/wiki-renderer/pom.xml
+++ b/data-upgrade-wiki-editor/wiki-renderer/pom.xml
@@ -352,7 +352,6 @@
     <dependency>
       <groupId>com.thoughtworks.xstream</groupId>
       <artifactId>xstream</artifactId>
-      <scope>provided</scope>
     </dependency>
 
   </dependencies>

--- a/data-upgrade-wiki-editor/wiki-service-xwiki/pom.xml
+++ b/data-upgrade-wiki-editor/wiki-service-xwiki/pom.xml
@@ -252,11 +252,6 @@
       <scope>runtime</scope>
     </dependency>
     <dependency>
-      <groupId>org.exoplatform.core</groupId>
-      <artifactId>exo.core.component.organization.jdbc</artifactId>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
       <groupId>xpp3</groupId>
       <artifactId>xpp3</artifactId>
       <scope>runtime</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -46,6 +46,7 @@
     <!-- **************************************** -->
 
     <version.chromattic>1.3.0</version.chromattic>
+    <version.xstream>1.4.15</version.xstream>
     <org.gatein.mop.version>1.3.2.Final</org.gatein.mop.version>
   </properties>
   <dependencyManagement>
@@ -196,6 +197,11 @@
         <artifactId>data-upgrade-packaging</artifactId>
         <version>${project.version}</version>
         <type>zip</type>
+      </dependency>
+      <dependency>
+        <groupId>com.thoughtworks.xstream</groupId>
+        <artifactId>xstream</artifactId>
+        <version>${version.xstream}</version>
       </dependency>
 
     </dependencies>


### PR DESCRIPTION
When removing xstream dependency, we completly remove module exo.core.component.jdbc which was deprecated
This commit remove the dependency on this module