### PR TITLE
TASK-40075 Fix Wiki Default Permissions for Sites

### DIFF
--- a/data-upgrade-packaging/pom.xml
+++ b/data-upgrade-packaging/pom.xml
@@ -64,6 +64,10 @@
       <groupId>${project.groupId}</groupId>
       <artifactId>data-upgrade-pages</artifactId>
     </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>data-upgrade-wiki</artifactId>
+    </dependency>
 
     <!-- Transitive dependencies provided by eXo : set to provided -->
     <dependency>

--- a/data-upgrade-wiki/pom.xml
+++ b/data-upgrade-wiki/pom.xml
@@ -1,0 +1,115 @@
+<!--
+
+    Copyright (C) 2009 eXo Platform SAS.
+    
+    This is free software; you can redistribute it and/or modify it
+    under the terms of the GNU Lesser General Public License as
+    published by the Free Software Foundation; either version 2.1 of
+    the License, or (at your option) any later version.
+    
+    This software is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+    Lesser General Public License for more details.
+    
+    You should have received a copy of the GNU Lesser General Public
+    License along with this software; if not, write to the Free
+    Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+    02110-1301 USA, or see the FSF site: http://www.fsf.org.
+
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.exoplatform.addons.upgrade</groupId>
+    <artifactId>upgrade</artifactId>
+    <version>6.2.x-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>data-upgrade-wiki</artifactId>
+  <packaging>jar</packaging>
+  <name>eXo Add-on:: Data Upgrade Add-on - Wiki - Upgrade</name>
+
+  <properties>
+    <exo.test.coverage.ratio>0.82</exo.test.coverage.ratio>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.exoplatform.kernel</groupId>
+      <artifactId>exo.kernel.container</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.exoplatform.core</groupId>
+      <artifactId>exo.core.component.security.core</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.exoplatform.commons</groupId>
+      <artifactId>commons-component-common</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.exoplatform.wiki</groupId>
+      <artifactId>wiki-service</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.exoplatform.commons</groupId>
+      <artifactId>commons-testing</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.exoplatform.gatein.portal</groupId>
+      <artifactId>exo.portal.component.identity</artifactId>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.exoplatform.gatein.portal</groupId>
+      <artifactId>exo.portal.component.portal</artifactId>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.exoplatform.gatein.portal</groupId>
+      <artifactId>exo.portal.component.application-registry</artifactId>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.exoplatform.gatein.portal</groupId>
+      <artifactId>exo.portal.component.test.core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.exoplatform.commons</groupId>
+      <artifactId>commons-component-common</artifactId>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.exoplatform.social</groupId>
+      <artifactId>social-component-core</artifactId>
+      <scope>test</scope>
+      <type>test-jar</type>
+    </dependency>
+    <dependency>
+      <groupId>org.hsqldb</groupId>
+      <artifactId>hsqldb</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/data-upgrade-wiki/src/main/java/org/exoplatform/wiki/upgrade/WikiGlobalPortalSiteUpgradePlugin.java
+++ b/data-upgrade-wiki/src/main/java/org/exoplatform/wiki/upgrade/WikiGlobalPortalSiteUpgradePlugin.java
@@ -1,0 +1,245 @@
+package org.exoplatform.wiki.upgrade;
+
+import java.util.*;
+
+import javax.persistence.EntityManager;
+import javax.persistence.Query;
+
+import org.apache.commons.lang3.StringUtils;
+
+import org.exoplatform.commons.persistence.impl.EntityManagerService;
+import org.exoplatform.commons.upgrade.UpgradeProductPlugin;
+import org.exoplatform.container.PortalContainer;
+import org.exoplatform.container.component.RequestLifeCycle;
+import org.exoplatform.container.xml.InitParams;
+import org.exoplatform.portal.config.DataStorage;
+import org.exoplatform.portal.config.UserACL;
+import org.exoplatform.portal.config.UserPortalConfigService;
+import org.exoplatform.portal.config.model.PortalConfig;
+import org.exoplatform.services.log.ExoLogger;
+import org.exoplatform.services.log.Log;
+import org.exoplatform.services.security.IdentityConstants;
+import org.exoplatform.wiki.WikiException;
+import org.exoplatform.wiki.mow.api.*;
+import org.exoplatform.wiki.service.*;
+import org.exoplatform.wiki.utils.Utils;
+
+public class WikiGlobalPortalSiteUpgradePlugin extends UpgradeProductPlugin {
+
+  private static final Log        LOG = ExoLogger.getLogger(WikiGlobalPortalSiteUpgradePlugin.class);
+
+  private PortalContainer         container;
+
+  private DataStorage             dataStorage;
+
+  private UserPortalConfigService portalConfigService;
+
+  private WikiService             wikiService;
+
+  private EntityManagerService    entityManagerService;
+
+  public WikiGlobalPortalSiteUpgradePlugin(PortalContainer container,
+                                           WikiService wikiService,
+                                           UserPortalConfigService portalConfigService,
+                                           DataStorage dataStorage,
+                                           EntityManagerService entityManagerService,
+                                           InitParams initParams) {
+    super(initParams);
+    this.container = container;
+    this.wikiService = wikiService;
+    this.portalConfigService = portalConfigService;
+    this.dataStorage = dataStorage;
+    this.entityManagerService = entityManagerService;
+  }
+
+  @Override
+  public void processUpgrade(String oldVersion, String newVersion) {
+    RequestLifeCycle.begin(container);
+    try {
+      String globalPortal = portalConfigService.getGlobalPortal();
+      Wiki globalSiteWiki = wikiService.getWikiByTypeAndOwner(PortalConfig.PORTAL_TYPE, globalPortal);
+      if (globalSiteWiki == null) {
+        LOG.info("--- Global Wiki Site migration: no global site wiki, nothing to migrate");
+        return;
+      }
+
+      String defaultPortal = portalConfigService.getDefaultPortal();
+
+      LOG.info("-- Global Wiki Site migration: Start updating wiki owner '{}' permissions to use owner '{}' default permissions",
+               globalPortal,
+               defaultPortal);
+      updateGlobalSiteWikiPermissions(globalPortal, defaultPortal, globalSiteWiki);
+      updateGlobalSiteWikiPagesPermissions(globalPortal, defaultPortal);
+      LOG.info("-- Global Wiki Site migration: End updating wiki owner '{}' permissions to use owner '{}' default permissions",
+               globalPortal,
+               defaultPortal);
+
+      Wiki defaultSiteWiki = wikiService.getWikiByTypeAndOwner(PortalConfig.PORTAL_TYPE, defaultPortal);
+      if (defaultSiteWiki != null) {
+        LOG.info("-- Global Wiki Site migration: default site has a wiki, the migration will not proceed");
+        return;
+      }
+
+      LOG.info("-- Global Wiki Site migration: Start updating wiki from owner '{}' to owner '{}'", globalPortal, defaultPortal);
+      EntityManager entityManager = entityManagerService.getEntityManager();
+      boolean transactionStarted = false;
+      if (entityManager.getTransaction() == null || !entityManager.getTransaction().isActive()) {
+        entityManager.getTransaction().begin();
+        transactionStarted = true;
+      }
+      try {
+        updatePageMoveEntities(globalPortal, defaultPortal);
+        updatePageEntities(globalPortal, defaultPortal);
+        updateWikiEntity(globalPortal, defaultPortal);
+      } finally {
+        if (transactionStarted) {
+          entityManager.getTransaction().commit();
+        }
+      }
+      LOG.info("-- Global Wiki Site migration: End updating wiki from owner '{}' to owner '{}'", globalPortal, defaultPortal);
+    } catch (Exception e) {
+      throw new IllegalStateException("Error while migrating global site wiki", e);
+    } finally {
+      RequestLifeCycle.end();
+    }
+
+    restartTransaction();
+  }
+
+  private List<PermissionEntry> getDefaultSitePermissions(String defaultPortal) throws WikiException {
+    List<PermissionEntry> wikiDefaultPermissions = wikiService.getWikiDefaultPermissions(PortalConfig.PORTAL_TYPE, defaultPortal);
+    wikiDefaultPermissions = Collections.unmodifiableList(wikiDefaultPermissions);
+    return wikiDefaultPermissions;
+  }
+
+  private void updateGlobalSiteWikiPagesPermissions(String globalPortal, String defaultPortal) throws Exception { // NOSONAR
+    List<PermissionEntry> pageDefaultPermissions = getPageDefaultPermissions(defaultPortal);
+    List<Page> pages = wikiService.getPagesOfWiki(PortalConfig.PORTAL_TYPE, globalPortal);
+    LOG.info("---- Global Wiki Site migration: Start updating global site wiki '{}' pages permissions updated to use default site permissions",
+             pages.size());
+    for (Page page : pages) {
+      List<PermissionEntry> pagePermissions = page.getPermissions();
+      if (pagePermissions != null && pagePermissions.stream()
+                                                    .anyMatch(permissionEntry -> StringUtils.equals(IdentityConstants.ANY,
+                                                                                                    permissionEntry.getId()))) {
+        page.setPermissions(pageDefaultPermissions);
+        wikiService.updatePage(page, PageUpdateType.EDIT_PAGE_PERMISSIONS);
+
+        LOG.info("----- Global Wiki Site migration: global site wiki page '{}' permissions updated to use default site permissions",
+                 page.getName());
+      } else {
+        LOG.info("----- Global Wiki Site migration: global site wiki page '{}' permissions NOT updated since it doesn't have permissions to 'ANY'",
+                 page.getName());
+      }
+    }
+    LOG.info("---- Global Wiki Site migration: End updating global site wiki '{}' pages permissions updated to use default site permissions",
+             pages.size());
+  }
+
+  private void updateGlobalSiteWikiPermissions(String globalPortal,
+                                               String defaultPortal,
+                                               Wiki globalSiteWiki) throws WikiException {
+    List<PermissionEntry> wikiDefaultPermissions = getDefaultSitePermissions(defaultPortal);
+    List<PermissionEntry> globalSitePermissions = globalSiteWiki.getPermissions();
+    if (globalSitePermissions != null && globalSitePermissions.stream()
+                                                              .anyMatch(permissionEntry -> StringUtils.equals(IdentityConstants.ANY,
+                                                                                                              permissionEntry.getId()))) {
+      wikiService.updateWikiPermission(PortalConfig.PORTAL_TYPE, globalPortal, wikiDefaultPermissions);
+      LOG.info("---- Global Wiki Site migration: global site wiki permissions updated to use default site permissions");
+    } else {
+      LOG.info("---- Global Wiki Site migration: global site wiki permissions NOT updated since it doesn't have permissions to 'ANY'");
+    }
+  }
+
+  private void updatePageEntities(String globalPortal, String defaultPortal) {
+    Query updatePageQuery = entityManagerService.getEntityManager()
+                                                .createQuery("UPDATE WikiPageEntity p SET p.owner = '" + defaultPortal
+                                                    + "' WHERE p.owner = '" + globalPortal + "'");
+    int updatedPageLines = updatePageQuery.executeUpdate();
+    LOG.info("---- Global Wiki Site migration: {} pages updated", updatedPageLines);
+  }
+
+  private void updateWikiEntity(String globalPortal, String defaultPortal) {
+    Query updateWikiQuery = entityManagerService.getEntityManager()
+                                                .createQuery("UPDATE WikiWikiEntity w SET w.owner = '" + defaultPortal
+                                                    + "' WHERE w.owner = '" + globalPortal + "'");
+    int updatedWikiLines = updateWikiQuery.executeUpdate();
+    LOG.info("---- Global Wiki Site migration: {} wiki updated", updatedWikiLines);
+  }
+
+  private void updatePageMoveEntities(String globalPortal, String defaultPortal) {
+    EntityManager entityManager = entityManagerService.getEntityManager();
+    Query updatePageMoveQuery = entityManager.createQuery("UPDATE WikiPageMoveEntity pm SET pm.wikiOwner = '"
+        + defaultPortal
+        + "' WHERE pm.wikiOwner = '" + globalPortal + "'");
+    int updatedPageMoveLines = updatePageMoveQuery.executeUpdate();
+    LOG.info("---- Global Wiki Site migration: {} PageMove updated", updatedPageMoveLines);
+  }
+
+  private void restartTransaction() {
+    int i = 0;
+    // Close transactions until no encapsulated transaction
+    boolean success = true;
+    do {
+      try {
+        RequestLifeCycle.end();
+        i++;
+      } catch (IllegalStateException e) {
+        success = false;
+      }
+    } while (success);
+
+    // Restart transactions with the same number of encapsulations
+    for (int j = 0; j < i; j++) {
+      RequestLifeCycle.begin(container);
+    }
+  }
+
+  private List<PermissionEntry> getPageDefaultPermissions(String wikiOwner) throws Exception {// NOSONAR
+    Permission[] allPermissions = new Permission[] {
+        new Permission(PermissionType.VIEWPAGE, true),
+        new Permission(PermissionType.EDITPAGE, true)
+    };
+    List<PermissionEntry> permissionEntries = new ArrayList<>();
+    Iterator<Map.Entry<String, IDType>> iter = Utils.getACLForAdmins().entrySet().iterator();
+    while (iter.hasNext()) {
+      Map.Entry<String, IDType> entry = iter.next();
+      PermissionEntry permissionEntry = new PermissionEntry(entry.getKey(), "", entry.getValue(), allPermissions);
+      permissionEntries.add(permissionEntry);
+    }
+    PortalConfig portalConfig = dataStorage.getPortalConfig(wikiOwner);
+    PermissionEntry portalPermissionEntry = new PermissionEntry(portalConfig.getEditPermission(),
+                                                                "",
+                                                                IDType.MEMBERSHIP,
+                                                                allPermissions);
+    permissionEntries.add(portalPermissionEntry);
+    String[] accessPermissions = portalConfig.getAccessPermissions();
+    if (accessPermissions != null && accessPermissions.length > 0) {
+      Permission[] viewPermissions = new Permission[] {
+          new Permission(PermissionType.VIEWPAGE, true),
+          new Permission(PermissionType.EDITPAGE, false)
+      };
+
+      for (String permissionExpression : accessPermissions) {
+        IDType idType = null;
+        if (StringUtils.equals(UserACL.EVERYONE, permissionExpression)) {
+          // Avoid to store ANY in wiki pages
+          continue;
+        } else if (StringUtils.contains(permissionExpression, "/") && StringUtils.contains(permissionExpression, ":")) {
+          idType = IDType.MEMBERSHIP;
+        } else if (StringUtils.contains(permissionExpression, "/")) {
+          idType = IDType.GROUP;
+        } else {
+          idType = IDType.USER;
+        }
+        PermissionEntry accessPermissionEntry = new PermissionEntry(permissionExpression,
+                                                                    "",
+                                                                    idType,
+                                                                    viewPermissions);
+        permissionEntries.add(accessPermissionEntry);
+      }
+    }
+    return permissionEntries;
+  }
+
+}

--- a/data-upgrade-wiki/src/main/resources/conf/portal/configuration.xml
+++ b/data-upgrade-wiki/src/main/resources/conf/portal/configuration.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<!--
+
+    Copyright (C) 2003-2021 eXo Platform SAS.
+
+    This is free software; you can redistribute it and/or modify it
+    under the terms of the GNU Lesser General Public License as
+    published by the Free Software Foundation; either version 3 of
+    the License, or (at your option) any later version.
+
+    This software is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+    Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public
+    License along with this software; if not, write to the Free
+    Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+    02110-1301 USA, or see the FSF site: http://www.fsf.org.
+
+-->
+<configuration xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.exoplatform.org/xml/ns/kernel_1_3.xsd http://www.exoplatform.org/xml/ns/kernel_1_3.xsd" xmlns="http://www.exoplatform.org/xml/ns/kernel_1_3.xsd">
+
+  <external-component-plugins>
+    <target-component>org.exoplatform.commons.upgrade.UpgradeProductService</target-component>
+    <component-plugin profiles="wiki">
+      <name>WikiGlobalPortalSiteUpgradePlugin</name>
+      <set-method>addUpgradePlugin</set-method>
+      <type>org.exoplatform.wiki.upgrade.WikiGlobalPortalSiteUpgradePlugin</type>
+      <description>Migrates the wiki owner 'global' to 'dw'</description>
+      <init-params>
+        <value-param>
+          <name>product.group.id</name>
+          <description>The groupId of the product</description>
+          <value>org.exoplatform.platform</value>
+        </value-param>
+        <value-param>
+          <name>plugin.execution.order</name>
+          <description>The plugin execution order</description>
+          <value>20</value>
+        </value-param>
+        <value-param>
+          <name>plugin.upgrade.execute.once</name>
+          <description>The plugin must be executed only once</description>
+          <value>true</value>
+        </value-param>
+        <value-param>
+          <name>plugin.upgrade.async.execution</name>
+          <description>The plugin will be executed in an asynchronous mode</description>
+          <value>false</value>
+        </value-param>
+      </init-params>
+    </component-plugin>
+  </external-component-plugins>
+</configuration>
+

--- a/data-upgrade-wiki/src/test/java/org/exoplatform/wiki/upgrade/WikiGlobalPortalSiteUpgradePluginTest.java
+++ b/data-upgrade-wiki/src/test/java/org/exoplatform/wiki/upgrade/WikiGlobalPortalSiteUpgradePluginTest.java
@@ -1,0 +1,110 @@
+package org.exoplatform.wiki.upgrade;
+
+import static org.junit.Assert.*;
+
+import java.util.List;
+
+import org.apache.commons.codec.binary.StringUtils;
+import org.junit.*;
+
+import org.exoplatform.commons.persistence.impl.EntityManagerService;
+import org.exoplatform.container.ExoContainerContext;
+import org.exoplatform.container.PortalContainer;
+import org.exoplatform.container.component.RequestLifeCycle;
+import org.exoplatform.container.xml.InitParams;
+import org.exoplatform.portal.config.DataStorage;
+import org.exoplatform.portal.config.UserPortalConfigService;
+import org.exoplatform.portal.config.model.PortalConfig;
+import org.exoplatform.services.security.IdentityConstants;
+import org.exoplatform.wiki.WikiException;
+import org.exoplatform.wiki.mow.api.*;
+import org.exoplatform.wiki.service.WikiService;
+
+public class WikiGlobalPortalSiteUpgradePluginTest {
+
+  protected PortalContainer         container;
+
+  protected WikiService             wikiService;
+
+  protected EntityManagerService    entityManagerService;
+
+  protected UserPortalConfigService portalConfigService;
+
+  protected DataStorage             dataStorage;
+
+  @Before
+  public void setUp() {
+    container = PortalContainer.getInstance();
+
+    wikiService = container.getComponentInstanceOfType(WikiService.class);
+    portalConfigService = container.getComponentInstanceOfType(UserPortalConfigService.class);
+    dataStorage = container.getComponentInstanceOfType(DataStorage.class);
+    entityManagerService = container.getComponentInstanceOfType(EntityManagerService.class);
+
+    begin();
+  }
+
+  @After
+  public void tearDown() {
+    end();
+  }
+
+  @Test
+  public void testWikiMigration() throws WikiException {
+    InitParams initParams = new InitParams();
+
+    String globalPortal = portalConfigService.getGlobalPortal();
+    String defaultPortal = portalConfigService.getDefaultPortal();
+
+    wikiService.createWiki(PortalConfig.PORTAL_TYPE, globalPortal);
+
+    List<Page> pages = wikiService.getPagesOfWiki(PortalConfig.PORTAL_TYPE, globalPortal);
+    int initialWikiPages = pages.size();
+    assertTrue(initialWikiPages > 0);
+
+    Wiki defaultSiteWiki = wikiService.getWikiByTypeAndOwner(PortalConfig.PORTAL_TYPE, defaultPortal);
+    assertNull(defaultSiteWiki);
+
+    WikiGlobalPortalSiteUpgradePlugin wikiGlobalPortalSiteUpgradePlugin =
+                                                                        new WikiGlobalPortalSiteUpgradePlugin(container,
+                                                                                                              wikiService,
+                                                                                                              portalConfigService,
+                                                                                                              dataStorage,
+                                                                                                              entityManagerService,
+                                                                                                              initParams);
+    wikiGlobalPortalSiteUpgradePlugin.processUpgrade(null, null);
+
+    defaultSiteWiki = wikiService.getWikiByTypeAndOwner(PortalConfig.PORTAL_TYPE, defaultPortal);
+    assertNotNull(defaultSiteWiki);
+
+    Wiki globalSiteWiki = wikiService.getWikiByTypeAndOwner(PortalConfig.PORTAL_TYPE, globalPortal);
+    assertNull(globalSiteWiki);
+
+    List<PermissionEntry> defaultSiteWikiPermissions = defaultSiteWiki.getPermissions();
+    assertNotNull(defaultSiteWikiPermissions);
+    assertTrue(defaultSiteWikiPermissions.stream()
+                                         .noneMatch(permissionEntry -> StringUtils.equals(permissionEntry.getId(),
+                                                                                          IdentityConstants.ANY)));
+
+    pages = wikiService.getPagesOfWiki(PortalConfig.PORTAL_TYPE, defaultPortal);
+    assertNotNull(pages);
+    assertEquals(initialWikiPages, pages.size());
+    for (Page page : pages) {
+      List<PermissionEntry> pagePermissions = page.getPermissions();
+      assertNotNull(pagePermissions);
+      assertTrue(pagePermissions.stream()
+                                .noneMatch(permissionEntry -> StringUtils.equals(permissionEntry.getId(),
+                                                                                 IdentityConstants.ANY)));
+    }
+  }
+
+  protected void begin() {
+    ExoContainerContext.setCurrentContainer(container);
+    RequestLifeCycle.begin(container);
+  }
+
+  protected void end() {
+    RequestLifeCycle.end();
+  }
+
+}

--- a/data-upgrade-wiki/src/test/resources/conf/portal/configuration.xml
+++ b/data-upgrade-wiki/src/test/resources/conf/portal/configuration.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<!--
+
+    Copyright (C) 2021 eXo Platform SAS.
+
+    This is free software; you can redistribute it and/or modify it
+    under the terms of the GNU Lesser General Public License as
+    published by the Free Software Foundation; either version 2.1 of
+    the License, or (at your option) any later version.
+
+    This software is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+    Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public
+    License along with this software; if not, write to the Free
+    Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+    02110-1301 USA, or see the FSF site: http://www.fsf.org.
+
+-->
+<configuration
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.exoplatform.org/xml/ns/kernel_1_2.xsd http://www.exoplatform.org/xml/ns/kernel_1_2.xsd"
+        xmlns="http://www.exoplatform.org/xml/ns/kernel_1_2.xsd">
+  <import>jar:/conf/exo.portal.component.identity-configuration.xml</import>
+  <import>jar:/conf/exo.portal.component.portal-configuration.xml</import>
+  <import>jar:/conf/exo.portal.component.application-registry-configuration.xml</import>
+  <import>jar:/conf/exo.commons.component.core-configuration.xml</import>
+  <import>jar:/conf/exo.social.component.core-configuration.xml</import>
+
+  <import>jar:/conf/portal/wiki-configuration.xml</import>
+
+  <remove-configuration>org.exoplatform.commons.search.service.UnifiedSearchService</remove-configuration>
+  <remove-configuration>org.exoplatform.commons.api.persistence.DataInitializer</remove-configuration>
+</configuration>

--- a/data-upgrade-wiki/src/test/resources/conf/portal/wiki-configuration.xml
+++ b/data-upgrade-wiki/src/test/resources/conf/portal/wiki-configuration.xml
@@ -1,0 +1,79 @@
+<configuration xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+               xsi:schemaLocation="http://www.exoplaform.org/xml/ns/kernel_1_2.xsd http://www.exoplaform.org/xml/ns/kernel_1_2.xsd"
+               xmlns="http://www.exoplaform.org/xml/ns/kernel_1_2.xsd">
+
+  <component>
+    <type>org.exoplatform.wiki.jpa.mock.DummyDependantComponent</type>
+  </component>
+
+  <component>
+    <key>org.exoplatform.wiki.service.DataStorage</key>
+    <type>org.exoplatform.wiki.jpa.JPADataStorage</type>
+  </component>
+  <component>
+    <type>org.exoplatform.wiki.jpa.dao.WikiDAO</type>
+  </component>
+  <component>
+    <type>org.exoplatform.wiki.jpa.dao.PageDAO</type>
+  </component>
+  <component>
+    <type>org.exoplatform.wiki.jpa.dao.PageAttachmentDAO</type>
+  </component>
+  <component>
+    <type>org.exoplatform.wiki.jpa.dao.DraftPageAttachmentDAO</type>
+  </component>
+  <component>
+    <type>org.exoplatform.wiki.jpa.dao.PageVersionDAO</type>
+  </component>
+  <component>
+    <type>org.exoplatform.wiki.jpa.dao.PageMoveDAO</type>
+  </component>
+  <component>
+    <type>org.exoplatform.wiki.jpa.dao.TemplateDAO</type>
+  </component>
+  <component>
+    <type>org.exoplatform.wiki.jpa.dao.EmotionIconDAO</type>
+  </component>
+
+  <component>
+    <key>org.exoplatform.wiki.rendering.RenderingService</key>
+    <type>org.exoplatform.wiki.rendering.impl.RenderingServiceImpl</type>
+  </component>
+
+  <component>
+    <key>org.exoplatform.wiki.service.WikiService</key>
+    <type>org.exoplatform.wiki.service.impl.WikiServiceImpl</type>
+    <init-params>
+      <value-param>
+        <name>wiki.editPage.livingTime</name>
+        <value>${wiki.editPage.livingTime:1800000}</value>
+        <!-- 30m * 60s * 1000ms -->
+      </value-param>
+      <value-param>
+        <name>attachment.upload.limit</name>
+        <value>10</value>
+      </value-param>
+      <properties-param>
+        <name>preferences</name>
+        <property name="defaultSyntax" value="xhtml/1.0"/>
+      </properties-param>
+    </init-params>
+  </component>
+  <component>
+    <type>org.exoplatform.wiki.jpa.search.WikiElasticUnifiedSearchServiceConnector</type>
+    <init-params>
+      <properties-param>
+        <name>constructor.params</name>
+        <property name="searchType" value="wiki"/>
+        <property name="displayName" value="Wiki"/>
+        <property name="index" value="wiki_alias"/>
+        <property name="type" value="wiki-page,wiki-attachment"/>
+        <property name="enable" value="${exo.unified-search.connector.wiki.enable:true}"/>
+        <property name="titleField" value="title"/>
+        <property name="updatedDateField" value="updatedDate"/>
+        <property name="searchFields" value="name,title,content,comment,attachment.content"/>
+      </properties-param>
+    </init-params>
+  </component>
+
+</configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,7 @@
   </scm>
   <modules>
     <module>data-upgrade-portal-rdbms</module>
+    <module>data-upgrade-wiki</module>
     <module>data-upgrade-wiki-editor</module>
     <module>data-upgrade-ecms</module>
     <module>data-upgrade-news</module>
@@ -190,6 +191,11 @@
       <dependency>
         <groupId>${project.groupId}</groupId>
         <artifactId>data-upgrade-pages</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>${project.groupId}</groupId>
+        <artifactId>data-upgrade-wiki</artifactId>
         <version>${project.version}</version>
       </dependency>
       <dependency>


### PR DESCRIPTION
By default All wiki pages of any Portal Site are accessible to all users ( see https://github.com/exoplatform/wiki/blob/6.2.0-M04/wiki-service/src/main/java/org/exoplatform/wiki/jpa/JPADataStorage.java#L1471-L1473 )
A fix has been made to copy all Portal Site Access permissions instead of making it accessible for everyone by default.
Knowing that Wiki Portal pages were previously created for global site only, this Upgrade plugin will:
1/ Migrate Wiki `global` site into `dw` site
2/ Change permissions of wiki and pages to reuse access and edit permissions of `dw` y default (in case `ANY` were added in Wiki or Page entities)