### PR TITLE
Task-41377: Fix PathNotFoundException from DlpFolderAndDriveMigration upgrade plugin

### DIFF
--- a/data-upgrade-dlp/src/main/resources/conf/portal/configuration.xml
+++ b/data-upgrade-dlp/src/main/resources/conf/portal/configuration.xml
@@ -99,10 +99,6 @@
         </value-param>
       </init-params>
     </component-plugin>
-  </external-component-plugins>
-
-  <external-component-plugins>
-    <target-component>org.exoplatform.commons.upgrade.UpgradeProductService</target-component>
     <component-plugin>
       <name>DlpFolderAndDriveMigration</name>
       <set-method>addUpgradePlugin</set-method>
@@ -111,12 +107,12 @@
         <value-param>
           <name>product.group.id</name>
           <description>The groupId of the product</description>
-          <value>org.exoplatform.ecms</value>
+          <value>org.exoplatform.platform</value>
         </value-param>
         <value-param>
           <name>plugin.execution.order</name>
           <description>The plugin execution order</description>
-          <value>3</value>
+          <value>10</value>
         </value-param>
         <value-param>
           <name>plugin.upgrade.execute.once</name>

--- a/data-upgrade-dlp/src/test/java/org/exoplatform/migration/dlp/DlpFolderAndDriveMigrationTest.java
+++ b/data-upgrade-dlp/src/test/java/org/exoplatform/migration/dlp/DlpFolderAndDriveMigrationTest.java
@@ -53,7 +53,7 @@ public class DlpFolderAndDriveMigrationTest {
   SettingService               settingService;
 
   @Test
-  public void testAdminDlpQuarantinePageMigration() throws Exception {
+  public void testDlpFolderAndDriveMigration() throws Exception {
 
     InitParams initParams = new InitParams();
 
@@ -73,6 +73,7 @@ public class DlpFolderAndDriveMigrationTest {
     when(repositoryService.getCurrentRepository()).thenReturn(repository);
     when(sessionProvider.getSession(any(), any())).thenReturn(session);
     when(session.getWorkspace()).thenReturn(workspace);
+    when(session.itemExists(any())).thenReturn(true);
     Node securityNode = mock(Node.class);
     when((Node) session.getItem("/Security")).thenReturn(securityNode);
     when(securityNode.hasNodes()).thenReturn(true);


### PR DESCRIPTION
- Before this fix a PathNotFoundException occurs with the 6.2.0-M10 fresh installation startup
- This PR fixes this exception, a check on security folder node existence is done before getting it