### PR TITLE
Task-44723 Upgrade Plugin NodeTypeUpgradePlugin is not launched betwe…

### DIFF
--- a/data-upgrade-ecms/src/main/resources/conf/portal/configuration.xml
+++ b/data-upgrade-ecms/src/main/resources/conf/portal/configuration.xml
@@ -48,40 +48,6 @@
         </value-param>
       </init-params>
     </component-plugin>
-  
-    <component-plugin>
-      <name>NodeTypeTemplateUpgradePlugin</name>
-      <set-method>addUpgradePlugin</set-method>
-      <type>org.exoplatform.ecms.upgrade.templates.NodeTypeTemplateUpgradePlugin</type>
-      <description>Upgrade templates for node types</description>
-      <init-params>
-        <value-param>
-          <name>product.group.id</name>
-          <description>The groupId of the product</description>
-          <value>org.exoplatform.ecms</value>
-        </value-param>
-        <value-param>
-          <name>plugin.execution.order</name>
-          <description>The plugin execution order</description>
-          <value>2</value>
-        </value-param>
-        <value-param>
-          <name>plugin.upgrade.execute.once</name>
-          <description>Execute this upgrade plugin only once</description>
-          <value>true</value>
-        </value-param>
-        <value-param>
-          <name>plugin.upgrade.async.execution</name>
-          <description>Execute this upgrade asynchronously</description>
-          <value>true</value>
-        </value-param>
-        <value-param>
-          <name>plugin.upgrade.target.version</name>
-          <description>Target version of the plugin</description>
-          <value>6.1.0</value>
-        </value-param>
-      </init-params>
-    </component-plugin>
 
     <component-plugin>
       <name>NodeTypeTemplateUpgradePlugin</name>
@@ -102,7 +68,7 @@
         <value-param>
           <name>plugin.upgrade.execute.once</name>
           <description>Execute this upgrade plugin only once</description>
-          <value>true</value>
+          <value>false</value>
         </value-param>
         <value-param>
           <name>plugin.upgrade.async.execution</name>


### PR DESCRIPTION
…en M19 and M20

Before this fix, the UP NodeTypeUpgradePlugin was not launch because it was already launched before. As it was configured as executeOnce=true, it was not relaunched.
This fix change executeOnce to false to let it start