### PR TITLE
Task-45012: Fix news indexing upgrade plugin execution

### DIFF
--- a/data-upgrade-news/src/main/java/org/exoplatform/news/upgrade/es/NewsIndexingUpgradePlugin.java
+++ b/data-upgrade-news/src/main/java/org/exoplatform/news/upgrade/es/NewsIndexingUpgradePlugin.java
@@ -27,8 +27,6 @@ import org.exoplatform.commons.upgrade.UpgradeProductPlugin;
 import org.exoplatform.container.xml.InitParams;
 import org.exoplatform.news.search.NewsIndexingServiceConnector;
 import org.exoplatform.services.jcr.RepositoryService;
-import org.exoplatform.services.jcr.core.ManageableRepository;
-import org.exoplatform.services.jcr.ext.app.SessionProviderService;
 import org.exoplatform.services.jcr.ext.common.SessionProvider;
 import org.exoplatform.services.log.ExoLogger;
 import org.exoplatform.services.log.Log;
@@ -44,18 +42,14 @@ public class NewsIndexingUpgradePlugin extends UpgradeProductPlugin {
 
   private final IndexingService   indexingService;
 
-  private SessionProviderService  sessionProviderService;
-
   private int                     newsIndexingCount;
 
   public NewsIndexingUpgradePlugin(InitParams initParams,
                                    RepositoryService repositoryService,
-                                   IndexingService indexingService,
-                                   SessionProviderService sessionProviderService) {
+                                   IndexingService indexingService) {
     super(initParams);
     this.repositoryService = repositoryService;
     this.indexingService = indexingService;
-    this.sessionProviderService = sessionProviderService;
   }
 
   @Override
@@ -64,9 +58,8 @@ public class NewsIndexingUpgradePlugin extends UpgradeProductPlugin {
     log.info("Start unindexing old news activities and indexing old news");
     SessionProvider sessionProvider = null;
     try {
-      ManageableRepository currentRepository = repositoryService.getCurrentRepository();
-      sessionProvider = sessionProviderService.getSessionProvider(null);
-      Session session = sessionProvider.getSession(COLLABORATION_WS, currentRepository);
+      sessionProvider = SessionProvider.createSystemProvider();
+      Session session = sessionProvider.getSession(COLLABORATION_WS, repositoryService.getCurrentRepository());
       QueryManager qm = session.getWorkspace().getQueryManager();
       Query q =
               qm.createQuery("select * from exo:news WHERE publication:currentState = 'published' AND jcr:path LIKE '/Groups/spaces/%'",

--- a/data-upgrade-news/src/main/resources/conf/portal/configuration.xml
+++ b/data-upgrade-news/src/main/resources/conf/portal/configuration.xml
@@ -71,7 +71,7 @@
         <value-param>
           <name>plugin.upgrade.execute.once</name>
           <description>Execute this upgrade plugin only once</description>
-          <value>true</value>
+          <value>false</value>
         </value-param>
         <value-param>
           <name>plugin.upgrade.async.execution</name>

--- a/data-upgrade-news/src/test/java/org/exoplatform/news/upgrade/es/NewsIndexingUpgradePluginTest.java
+++ b/data-upgrade-news/src/test/java/org/exoplatform/news/upgrade/es/NewsIndexingUpgradePluginTest.java
@@ -1,29 +1,31 @@
 package org.exoplatform.news.upgrade.es;
 
-import static org.junit.Assert.*;
-import static org.mockito.Matchers.any;
+import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.anyString;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
-import javax.jcr.*;
+import javax.jcr.Node;
+import javax.jcr.NodeIterator;
+import javax.jcr.Property;
+import javax.jcr.Workspace;
 import javax.jcr.query.Query;
 import javax.jcr.query.QueryManager;
 import javax.jcr.query.QueryResult;
 
-import org.exoplatform.commons.search.index.IndexingService;
-import org.exoplatform.services.jcr.impl.core.query.QueryImpl;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.powermock.modules.junit4.PowerMockRunner;
 
+import org.exoplatform.commons.search.index.IndexingService;
 import org.exoplatform.container.xml.InitParams;
 import org.exoplatform.container.xml.ValueParam;
 import org.exoplatform.services.jcr.RepositoryService;
 import org.exoplatform.services.jcr.config.RepositoryEntry;
+import org.exoplatform.services.jcr.core.ExtendedSession;
 import org.exoplatform.services.jcr.core.ManageableRepository;
-import org.exoplatform.services.jcr.ext.app.SessionProviderService;
-import org.exoplatform.services.jcr.ext.common.SessionProvider;
+import org.exoplatform.services.jcr.impl.core.query.QueryImpl;
 
 @RunWith(PowerMockRunner.class)
 public class NewsIndexingUpgradePluginTest {
@@ -35,19 +37,13 @@ public class NewsIndexingUpgradePluginTest {
   IndexingService        indexingService;
 
   @Mock
-  SessionProviderService sessionProviderService;
-
-  @Mock
   ManageableRepository   repository;
 
   @Mock
   RepositoryEntry        repositoryEntry;
 
   @Mock
-  SessionProvider        sessionProvider;
-
-  @Mock
-  Session                session;
+  ExtendedSession                session;
 
   @Test
   public void testOdlNewsIndexing() throws Exception {
@@ -58,11 +54,9 @@ public class NewsIndexingUpgradePluginTest {
     valueParam.setValue("org.exoplatform.addons.news");
     initParams.addParameter(valueParam);
 
-    when(sessionProviderService.getSessionProvider(any())).thenReturn(sessionProvider);
     when(repositoryService.getCurrentRepository()).thenReturn(repository);
     when(repository.getConfiguration()).thenReturn(repositoryEntry);
-    when(repositoryEntry.getDefaultWorkspaceName()).thenReturn("collaboration");
-    when(sessionProvider.getSession(any(), any())).thenReturn(session);
+    when(repository.getSystemSession(anyString())).thenReturn(session);
     QueryManager qm = mock(QueryManager.class);
     Workspace workSpace = mock(Workspace.class);
     when(session.getWorkspace()).thenReturn(workSpace);
@@ -82,8 +76,7 @@ public class NewsIndexingUpgradePluginTest {
 
     NewsIndexingUpgradePlugin newsIndexingUpgradePlugin = new NewsIndexingUpgradePlugin(initParams,
                                                                                         repositoryService,
-                                                                                        indexingService,
-                                                                                        sessionProviderService);
+                                                                                        indexingService);
     newsIndexingUpgradePlugin.processUpgrade(null, null);
 
     assertEquals(2, newsIndexingUpgradePlugin.getNewsIndexingCount());


### PR DESCRIPTION
Prior to this change, the news indexing upgrade plugin execution fails sometimes with NPE on sessionProvider, thus we use SessionProvider.createSystemProvider() instead of sessionProviderService.getSessionProvider(null) to avoid this failure. In order to ensure the execution of the news indexing upgrade plugin for next Milestone we set plugin.upgrade.execute.once to true, to be set to false after the next Milestone release.