### PR TITLE
Task-45012: Ensure executing NewsIndexingUpgradePlugin only once

### DIFF
--- a/data-upgrade-news/src/main/resources/conf/portal/configuration.xml
+++ b/data-upgrade-news/src/main/resources/conf/portal/configuration.xml
@@ -71,7 +71,7 @@
         <value-param>
           <name>plugin.upgrade.execute.once</name>
           <description>Execute this upgrade plugin only once</description>
-          <value>false</value>
+          <value>true</value>
         </value-param>
         <value-param>
           <name>plugin.upgrade.async.execution</name>


### PR DESCRIPTION
Prior to this change, the NewsIndexingUpgradePlugin is executed for each upgrade since it was needed to be re-executed after its failure. Thus we should ensure that it should again be executed only once