### PR TITLE
Task-45575: Add WCMTemplateUpgradePlugin in order to upgrade WCM templates

### DIFF
--- a/data-upgrade-ecms/src/main/java/org/exoplatform/ecms/upgrade/templates/NodeTypeTemplateUpgradePlugin.java
+++ b/data-upgrade-ecms/src/main/java/org/exoplatform/ecms/upgrade/templates/NodeTypeTemplateUpgradePlugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2003-2012 eXo Platform SAS.
+ * Copyright (C) 2003-2021 eXo Platform SAS.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/data-upgrade-ecms/src/main/java/org/exoplatform/ecms/upgrade/templates/WCMTemplateUpgradePlugin.java
+++ b/data-upgrade-ecms/src/main/java/org/exoplatform/ecms/upgrade/templates/WCMTemplateUpgradePlugin.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright (C) 2003-2021 eXo Platform SAS.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.exoplatform.ecms.upgrade.templates;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import javax.jcr.Node;
+import javax.jcr.NodeIterator;
+import javax.jcr.query.Query;
+import javax.jcr.query.QueryManager;
+
+import org.apache.commons.lang.StringUtils;
+
+import org.exoplatform.commons.upgrade.UpgradeProductPlugin;
+import org.exoplatform.commons.utils.PrivilegedSystemHelper;
+import org.exoplatform.container.xml.InitParams;
+import org.exoplatform.services.cms.views.ApplicationTemplateManagerService;
+import org.exoplatform.services.cms.views.impl.ApplicationTemplateManagerServiceImpl;
+import org.exoplatform.services.jcr.ext.common.SessionProvider;
+import org.exoplatform.services.log.ExoLogger;
+import org.exoplatform.services.log.Log;
+
+public class WCMTemplateUpgradePlugin extends UpgradeProductPlugin {
+
+  private static final Log log = ExoLogger.getLogger(WCMTemplateUpgradePlugin.class.getName());
+  private ApplicationTemplateManagerService appTemplateService_;
+  
+  public WCMTemplateUpgradePlugin(ApplicationTemplateManagerService appTemplateService, InitParams initParams) {
+    super(initParams);
+    this.appTemplateService_ = appTemplateService;
+  }
+
+  public void processUpgrade(String oldVersion, String newVersion) {
+    if (log.isInfoEnabled()) {
+      log.info("Start " + this.getClass().getName() + ".............");
+    }
+    String unchangedClvTemplates = PrivilegedSystemHelper.getProperty("unchanged-clv-templates");
+    String unchangedSearchTemplates = PrivilegedSystemHelper.getProperty("unchanged-wcm-search-templates");
+    upgrade(unchangedClvTemplates, "content-list-viewer");
+    upgrade(unchangedSearchTemplates, "search");
+    
+    try {
+      // re-initialize new scripts
+      ((ApplicationTemplateManagerServiceImpl)appTemplateService_).start();
+    } catch (Exception e) {
+      if (log.isErrorEnabled()) {
+        log.error("An unexpected error occurs when migrating templates for portlet CLV and WCMSearch: ", e);        
+      }
+    }
+  }
+  
+  private void upgrade(String unchangedTemplates, String portletName) {
+    SessionProvider sessionProvider = null;
+    if (StringUtils.isEmpty(unchangedTemplates)) {
+      unchangedTemplates = "";
+    }
+    try {
+      Set<String> unchangedTemplateSet = new HashSet<String>();
+      Set<String> configuredTemplates = appTemplateService_.getConfiguredAppTemplateMap(portletName);
+      List<Node> removedNodes = new ArrayList<Node>();
+      for (String unchangedTemplate : unchangedTemplates.split(",")) {
+        unchangedTemplateSet.add(unchangedTemplate.trim());
+      }
+      //get all old query nodes that need to be removed.
+      sessionProvider = SessionProvider.createSystemProvider();
+      Node templateHomeNode = appTemplateService_.getApplicationTemplateHome(portletName, sessionProvider);
+      QueryManager queryManager = templateHomeNode.getSession().getWorkspace().getQueryManager();
+      NodeIterator iter = queryManager.
+          createQuery("SELECT * FROM nt:file WHERE jcr:path LIKE '" + templateHomeNode.getPath() + "/%'", Query.SQL).
+          execute().getNodes();
+      while (iter.hasNext()) {
+        Node templateNode = iter.nextNode();
+        if (!unchangedTemplateSet.contains(templateNode.getPath().substring(templateHomeNode.getPath().length() + 1)) && 
+            configuredTemplates.contains(templateNode.getPath().substring(templateHomeNode.getPath().length() + 1))) {
+          removedNodes.add(templateNode);
+        }
+      }
+      //remove all old script nodes
+      for (Node removedNode : removedNodes) {
+        try {
+          String removedTemplateName = removedNode.getName();
+          removedNode.remove();
+          templateHomeNode.save();
+          if (log.isInfoEnabled()) {
+            log.info("Update WCM template {} with a new version", removedTemplateName);
+          }
+        } catch (Exception e) {
+          if (log.isErrorEnabled()) {
+            log.error("Error in " + this.getName() + ": Can not remove old template: " + removedNode.getPath());
+          }
+        }
+      }
+    } catch (Exception e) {
+      if (log.isErrorEnabled()) {
+        log.error("An unexpected error occurs when migrating templates for portlet: " + portletName + ": ", e);        
+      }
+    } finally {
+      if (sessionProvider != null) {
+        sessionProvider.close();
+      }
+    }
+  }
+}

--- a/data-upgrade-ecms/src/main/java/org/exoplatform/ecms/upgrade/views/SiteExplorerTemplateUpgradePlugin.java
+++ b/data-upgrade-ecms/src/main/java/org/exoplatform/ecms/upgrade/views/SiteExplorerTemplateUpgradePlugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2003-2020 eXo Platform SAS.
+ * Copyright (C) 2003-2021 eXo Platform SAS.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/data-upgrade-ecms/src/main/resources/conf/portal/configuration.xml
+++ b/data-upgrade-ecms/src/main/resources/conf/portal/configuration.xml
@@ -82,6 +82,40 @@
         </value-param>
       </init-params>
     </component-plugin>
+    
+    <component-plugin>
+      <name>WCMTemplateUpgradePlugin</name>
+      <set-method>addUpgradePlugin</set-method>
+      <type>org.exoplatform.ecms.upgrade.templates.WCMTemplateUpgradePlugin</type>
+      <description>Upgrade view templates of WCM like CLV templates and search templates</description>
+      <init-params>
+        <value-param>
+          <name>product.group.id</name>
+          <description>The groupId of the product</description>
+          <value>org.exoplatform.ecms</value>
+        </value-param>
+        <value-param>
+          <name>plugin.execution.order</name>
+          <description>The plugin execution order</description>
+          <value>2</value>
+        </value-param>
+        <value-param>
+          <name>plugin.upgrade.execute.once</name>
+          <description>Execute this upgrade plugin only once</description>
+          <value>false</value>
+        </value-param>
+        <value-param>
+          <name>plugin.upgrade.async.execution</name>
+          <description>Execute this upgrade asynchronously</description>
+          <value>true</value>
+        </value-param>
+        <value-param>
+          <name>plugin.upgrade.target.version</name>
+          <description>Target version of the plugin</description>
+          <value>6.2.0</value>
+        </value-param>
+      </init-params>
+    </component-plugin>
   </external-component-plugins>
 </configuration>
 

--- a/data-upgrade-ecms/src/test/java/org/exoplatform/ecms/upgrade/templates/NodeTypeTemplateUpgradePluginTest.java
+++ b/data-upgrade-ecms/src/test/java/org/exoplatform/ecms/upgrade/templates/NodeTypeTemplateUpgradePluginTest.java
@@ -1,34 +1,33 @@
 package org.exoplatform.ecms.upgrade.templates;
 
-import org.exoplatform.commons.info.ProductInformations;
-import org.exoplatform.container.xml.InitParams;
-import org.exoplatform.container.xml.ValueParam;
-import org.exoplatform.services.cms.templates.TemplateService;
-import org.exoplatform.services.cms.impl.Utils;
-import org.exoplatform.services.cms.templates.impl.TemplateServiceImpl;
-import org.exoplatform.services.jcr.core.ExtendedSession;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.Mock;
-import org.mockito.Mockito;
-import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.HashSet;
+import java.util.Set;
 
 import javax.jcr.Node;
 import javax.jcr.NodeIterator;
 import javax.jcr.Workspace;
 
-import java.util.HashSet;
-import java.util.Set;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
 
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyBoolean;
-import static org.mockito.Matchers.anyString;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import org.exoplatform.commons.info.ProductInformations;
+import org.exoplatform.container.xml.InitParams;
+import org.exoplatform.container.xml.ValueParam;
+import org.exoplatform.services.cms.impl.Utils;
+import org.exoplatform.services.cms.templates.impl.TemplateServiceImpl;
+import org.exoplatform.services.jcr.core.ExtendedSession;
 
 @RunWith(PowerMockRunner.class)
 @PrepareForTest(Utils.class)

--- a/data-upgrade-ecms/src/test/java/org/exoplatform/ecms/upgrade/templates/WCMTemplateUpgradePluginTest.java
+++ b/data-upgrade-ecms/src/test/java/org/exoplatform/ecms/upgrade/templates/WCMTemplateUpgradePluginTest.java
@@ -1,0 +1,98 @@
+package org.exoplatform.ecms.upgrade.templates;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import javax.jcr.Node;
+import javax.jcr.NodeIterator;
+import javax.jcr.Workspace;
+import javax.jcr.query.Query;
+import javax.jcr.query.QueryManager;
+import javax.jcr.query.QueryResult;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import org.exoplatform.commons.info.ProductInformations;
+import org.exoplatform.container.xml.InitParams;
+import org.exoplatform.container.xml.ValueParam;
+import org.exoplatform.services.cms.impl.Utils;
+import org.exoplatform.services.cms.views.impl.ApplicationTemplateManagerServiceImpl;
+import org.exoplatform.services.jcr.core.ExtendedSession;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest(Utils.class)
+public class WCMTemplateUpgradePluginTest {
+
+  @Mock
+  ApplicationTemplateManagerServiceImpl applicationTemplateManagerService;
+
+  @Mock
+  ProductInformations                   productInformations;
+
+  @Mock
+  ExtendedSession                       session;
+
+  @Mock
+  NodeIterator                          nodeIterator;
+
+  @Mock
+  QueryManager                          queryManager;
+
+  @Test
+  public void testWCMTemplateMigration() throws Exception {
+    InitParams initParams = new InitParams();
+
+    ValueParam valueParam = new ValueParam();
+    valueParam.setName("product.group.id");
+    valueParam.setValue("org.exoplatform.ecms");
+    initParams.addParameter(valueParam);
+
+    Node templateHomeNode = mock(Node.class);
+    when(applicationTemplateManagerService.getApplicationTemplateHome(any(), any())).thenReturn(templateHomeNode);
+    when(templateHomeNode.getPath()).thenReturn("/templateHomeNodePath");
+    Set<String> configuredTemplates = new HashSet<>();
+    configuredTemplates.add("template1");
+    configuredTemplates.add("template2");
+    configuredTemplates.add("template3");
+    when(applicationTemplateManagerService.getConfiguredAppTemplateMap(any())).thenReturn(configuredTemplates);
+
+    when(templateHomeNode.getSession()).thenReturn(session);
+    Workspace workspace = mock(Workspace.class);
+    when(session.getWorkspace()).thenReturn(workspace);
+    when(workspace.getQueryManager()).thenReturn(queryManager);
+    Query query = mock(Query.class);
+    when(queryManager.createQuery(anyString(), anyString())).thenReturn(query);
+    QueryResult queryResult = mock(QueryResult.class);
+    when(query.execute()).thenReturn(queryResult);
+    when(queryResult.getNodes()).thenReturn(nodeIterator);
+
+    when(nodeIterator.hasNext()).thenReturn(true, true, true, false);
+    Node templateNode1 = mock(Node.class);
+    when(templateNode1.getName()).thenReturn("template1");
+    when(templateNode1.getPath()).thenReturn("/templateHomeNodePath/template1");
+    Node templateNode2 = mock(Node.class);
+    when(templateNode2.getName()).thenReturn("template2");
+    when(templateNode2.getPath()).thenReturn("/templateHomeNodePath/template2");
+    Node templateNode3 = mock(Node.class);
+    when(templateNode3.getName()).thenReturn("template3");
+    when(templateNode3.getPath()).thenReturn("/templateHomeNodePath/template3");
+
+    when(nodeIterator.nextNode()).thenReturn(templateNode1).thenReturn(templateNode2).thenReturn(templateNode3);
+
+    WCMTemplateUpgradePlugin wcmTemplateUpgradePlugin = new WCMTemplateUpgradePlugin(applicationTemplateManagerService, initParams);
+    wcmTemplateUpgradePlugin.processUpgrade(null, null);
+    verify(templateHomeNode, times(3)).save();
+    verify(applicationTemplateManagerService, times(1)).start();
+  }
+}

--- a/data-upgrade-ecms/src/test/java/org/exoplatform/ecms/upgrade/views/SiteExplorerTemplateUpgradePluginTest.java
+++ b/data-upgrade-ecms/src/test/java/org/exoplatform/ecms/upgrade/views/SiteExplorerTemplateUpgradePluginTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2003-2020 eXo Platform SAS.
+ * Copyright (C) 2003-2021 eXo Platform SAS.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by
@@ -16,23 +16,23 @@
  */
 package org.exoplatform.ecms.upgrade.views;
 
-import java.util.ArrayList;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 
 import javax.jcr.Node;
 import javax.jcr.NodeIterator;
-import javax.jcr.Session;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.powermock.modules.junit4.PowerMockRunner;
-
-import static org.junit.Assert.*;
-import static org.mockito.Matchers.*;
-import static org.mockito.Mockito.*;
 
 import org.exoplatform.container.xml.InitParams;
 import org.exoplatform.container.xml.ValueParam;


### PR DESCRIPTION
Prior to this change, when a WCM template is modified on a product version, this modification is not upgraded on the template already deployed on instances with a previous version. After this change, the upgrade will be done.