### PR TITLE
TASK-40732: Add upgrade plugin for chat and Agenda Notifications Settings

### DIFF
--- a/data-upgrade-portal-rdbms/pom.xml
+++ b/data-upgrade-portal-rdbms/pom.xml
@@ -1,0 +1,66 @@
+<!-- Copyright (C) 2021 eXo Platform SAS. This is free software; you can 
+  redistribute it and/or modify it under the terms of the GNU Lesser General 
+  Public License as published by the Free Software Foundation; either version 
+  2.1 of the License, or (at your option) any later version. This software 
+  is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; 
+  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR 
+  PURPOSE. See the GNU Lesser General Public License for more details. You 
+  should have received a copy of the GNU Lesser General Public License along 
+  with this software; if not, write to the Free Software Foundation, Inc., 
+  51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA, or see the FSF site: 
+  http://www.fsf.org. -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.exoplatform.addons.upgrade</groupId>
+    <artifactId>upgrade</artifactId>
+    <version>6.2.x-maintenance-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>data-upgrade-portal-rdbms</artifactId>
+  <packaging>jar</packaging>
+  <name>eXo Add-on:: Data Upgrade - PORTAL</name>
+
+  <properties>
+    <exo.test.coverage.ratio>1</exo.test.coverage.ratio>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.exoplatform.commons</groupId>
+      <artifactId>commons-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.exoplatform.commons</groupId>
+      <artifactId>commons-component-upgrade</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-api-mockito2</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-module-junit4</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/data-upgrade-portal-rdbms/src/main/java/org/exoplatform/portal/upgrade/notification/NotificationSettingsUpgradePlugin.java
+++ b/data-upgrade-portal-rdbms/src/main/java/org/exoplatform/portal/upgrade/notification/NotificationSettingsUpgradePlugin.java
@@ -1,0 +1,125 @@
+package org.exoplatform.portal.upgrade.notification;
+
+import org.exoplatform.commons.api.notification.model.PluginInfo;
+import org.exoplatform.commons.api.notification.model.UserSetting;
+import org.exoplatform.commons.api.notification.service.setting.PluginSettingService;
+import org.exoplatform.commons.api.notification.service.setting.UserSettingService;
+import org.exoplatform.commons.api.settings.SettingService;
+import org.exoplatform.commons.api.settings.data.Context;
+import org.exoplatform.commons.persistence.impl.EntityManagerService;
+import org.exoplatform.commons.upgrade.UpgradeProductPlugin;
+import org.exoplatform.container.ExoContainer;
+import org.exoplatform.container.ExoContainerContext;
+import org.exoplatform.container.xml.InitParams;
+import org.exoplatform.services.log.ExoLogger;
+import org.exoplatform.services.log.Log;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+public class NotificationSettingsUpgradePlugin extends UpgradeProductPlugin {
+  private static final Log LOG = ExoLogger.getLogger(NotificationSettingsUpgradePlugin.class);
+
+  private static final String EVENT_ADDED_PLUGIN_TYPE = "EventAddedNotificationPlugin";
+  private static final String EVENT_MODIFIED_PLUGIN_TYPE = "EventModifiedNotificationPlugin";
+  private static final String EVENT_CANCELED_PLUGIN_TYPE = "EventCanceledNotificationPlugin";
+  private static final String EVENT_REMINDER_PLUGIN_TYPE = "EventReminderNotificationPlugin";
+  private static final String CHAT_MENTION_PLUGIN_TYPE = "ChatMentionNotificationPlugin";
+
+  private ArrayList<String> pluginTypes = new ArrayList<>(Arrays.asList(EVENT_ADDED_PLUGIN_TYPE, EVENT_MODIFIED_PLUGIN_TYPE, EVENT_CANCELED_PLUGIN_TYPE, EVENT_REMINDER_PLUGIN_TYPE, CHAT_MENTION_PLUGIN_TYPE));
+
+  private SettingService settingService;
+
+  private UserSettingService userSettingService;
+
+  private PluginSettingService pluginSettingService;
+
+  private EntityManagerService entityManagerService;
+
+  public NotificationSettingsUpgradePlugin(SettingService settingService,
+                                           UserSettingService userSettingService,
+                                           PluginSettingService pluginSettingService,
+                                           EntityManagerService entityManagerService,
+                                           InitParams initParams) {
+    super(settingService, initParams);
+    this.settingService = settingService;
+    this.userSettingService = userSettingService;
+    this.pluginSettingService = pluginSettingService;
+    this.entityManagerService = entityManagerService;
+  }
+
+  @Override
+  public void processUpgrade(String oldVersion, String newVersion) {
+    ExoContainer currentContainer = ExoContainerContext.getCurrentContainer();
+
+    for (String pluginType : pluginTypes) {
+      int pageSize = 20;
+      int current = 0;
+      try {
+        LOG.info("=== Start initialisation of {} settings", pluginType);
+        LOG.info("  Starting activating {} Notifications for users", pluginType);
+
+        PluginInfo pluginTypeConfig = findPlugin(pluginType);
+        List<String> usersContexts;
+
+        entityManagerService.startRequest(currentContainer);
+        long startTime = System.currentTimeMillis();
+        do {
+          LOG.info("  Progression of users {} Notifications settings initialisation : {} users", pluginType, current);
+
+          // Get all users who already update their notification settings
+          usersContexts = settingService.getContextNamesByType(Context.USER.getName(), current, pageSize);
+
+          if (usersContexts != null) {
+            for (String userName : usersContexts) {
+              try {
+                entityManagerService.endRequest(currentContainer);
+                entityManagerService.startRequest(currentContainer);
+
+                UserSetting userSetting = this.userSettingService.get(userName);
+                if (userSetting != null) {
+                  updateSetting(userSetting, pluginTypeConfig);
+                  userSettingService.save(userSetting);
+                }
+              } catch (Exception e) {
+                LOG.error("  Error while activating {} Notifications for user {} ", pluginType, userName, e);
+              }
+            }
+            current += usersContexts.size();
+          }
+        } while (usersContexts != null && !usersContexts.isEmpty());
+        long endTime = System.currentTimeMillis();
+        LOG.info("  Users {} Notifications settings initialised in {} ms", pluginType, (endTime - startTime));
+      } catch (Exception e) {
+        LOG.error("Error while initialisation of users {} Notifications settings - Cause :", pluginType, e.getMessage(), e);
+      } finally {
+        entityManagerService.endRequest(currentContainer);
+      }
+
+      LOG.info("=== {} users with modified notifications settings have been found and processed successfully", current);
+      LOG.info("=== End initialisation of {} Notifications settings", pluginType);
+    }
+  }
+
+  private PluginInfo findPlugin(String type) {
+    for (PluginInfo plugin : pluginSettingService.getAllPlugins()) {
+      if (plugin.getType().equals(type)) {
+        return plugin;
+      }
+    }
+    return null;
+  }
+
+  private void updateSetting(UserSetting userSetting, PluginInfo config) {
+    for (String defaultConf : config.getDefaultConfig()) {
+      for (String channelId : config.getAllChannelActive()) {
+        if (UserSetting.FREQUENCY.getFrequecy(defaultConf) == UserSetting.FREQUENCY.INSTANTLY) {
+          userSetting.addChannelPlugin(channelId, config.getType());
+        } else {
+          userSetting.addPlugin(config.getType(), UserSetting.FREQUENCY.getFrequecy(defaultConf));
+        }
+      }
+    }
+  }
+}

--- a/data-upgrade-portal-rdbms/src/main/resources/conf/portal/configuration.xml
+++ b/data-upgrade-portal-rdbms/src/main/resources/conf/portal/configuration.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<!--
+
+    Copyright (C) 2003-2021 eXo Platform SAS.
+
+    This is free software; you can redistribute it and/or modify it
+    under the terms of the GNU Lesser General Public License as
+    published by the Free Software Foundation; either version 3 of
+    the License, or (at your option) any later version.
+
+    This software is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+    Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public
+    License along with this software; if not, write to the Free
+    Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+    02110-1301 USA, or see the FSF site: http://www.fsf.org.
+
+-->
+<configuration xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.exoplatform.org/xml/ns/kernel_1_3.xsd http://www.exoplatform.org/xml/ns/kernel_1_3.xsd" xmlns="http://www.exoplatform.org/xml/ns/kernel_1_3.xsd">
+
+  <external-component-plugins>
+    <target-component>org.exoplatform.commons.upgrade.UpgradeProductService</target-component>
+    <component-plugin>
+      <name>NotificationSettingsUpgradePlugin</name>
+      <set-method>addUpgradePlugin</set-method>
+      <type>org.exoplatform.portal.upgrade.notification.NotificationSettingsUpgradePlugin</type>
+      <description>eXo Notification Upgrade Updater</description>
+      <init-params>
+        <value-param>
+          <name>product.group.id</name>
+          <description>The groupId of the product</description>
+          <value>org.exoplatform.portal</value>
+        </value-param>
+        <value-param>
+          <name>plugin.execution.order</name>
+          <description>The plugin execution order</description>
+          <value>1</value>
+        </value-param>
+        <value-param>
+          <name>plugin.upgrade.execute.once</name>
+          <description>Execute this upgrade plugin only once</description>
+          <value>true</value>
+        </value-param>
+        <value-param>
+          <name>plugin.upgrade.target.version</name>
+          <description>Target version of the plugin</description>
+          <value>6.2.x</value>
+        </value-param>
+        <value-param>
+          <name>plugin.upgrade.async.execution</name>
+          <description>Execute this upgrade asynchronously</description>
+          <value>true</value>
+        </value-param>
+      </init-params>
+    </component-plugin>
+  </external-component-plugins>
+</configuration>
+

--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,7 @@
     <module>data-upgrade-news</module>
     <module>data-upgrade-pages</module>
     <module>data-upgrade-dlp</module>
+    <module>data-upgrade-portal-rdbms</module>
     <module>data-upgrade-packaging</module>
   </modules>
   <properties>


### PR DESCRIPTION
I added an upgrade plugin to initialize the notification settings of the Agenda add-on and the chat add-on to the default settings for all users. This upgrade plugin can be used in order to modify default notification settings.