### PR TITLE
MAINT-41630: Make notifications types settings activated by default after upgrade

### DIFF
--- a/data-upgrade-notifications/pom.xml
+++ b/data-upgrade-notifications/pom.xml
@@ -19,9 +19,9 @@
     <version>6.3.x-SNAPSHOT</version>
   </parent>
 
-  <artifactId>data-upgrade-portal-rdbms</artifactId>
+  <artifactId>data-upgrade-notifications</artifactId>
   <packaging>jar</packaging>
-  <name>eXo Add-on:: Data Upgrade - PORTAL</name>
+  <name>eXo Add-on:: Data Upgrade - Notifications</name>
 
   <properties>
     <exo.test.coverage.ratio>1</exo.test.coverage.ratio>
@@ -37,31 +37,6 @@
       <groupId>org.exoplatform.commons</groupId>
       <artifactId>commons-component-upgrade</artifactId>
       <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-core</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-api-mockito2</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-module-junit4</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-simple</artifactId>
-      <scope>test</scope>
     </dependency>
   </dependencies>
 </project>

--- a/data-upgrade-notifications/src/main/java/org/exoplatform/portal/upgrade/notification/NotificationSettingsUpgradePlugin.java
+++ b/data-upgrade-notifications/src/main/java/org/exoplatform/portal/upgrade/notification/NotificationSettingsUpgradePlugin.java
@@ -1,5 +1,8 @@
 package org.exoplatform.portal.upgrade.notification;
 
+import java.util.Arrays;
+import java.util.List;
+
 import org.exoplatform.commons.api.notification.model.PluginInfo;
 import org.exoplatform.commons.api.notification.model.UserSetting;
 import org.exoplatform.commons.api.notification.service.setting.PluginSettingService;
@@ -14,28 +17,20 @@ import org.exoplatform.container.xml.InitParams;
 import org.exoplatform.services.log.ExoLogger;
 import org.exoplatform.services.log.Log;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-
 public class NotificationSettingsUpgradePlugin extends UpgradeProductPlugin {
-  private static final Log LOG = ExoLogger.getLogger(NotificationSettingsUpgradePlugin.class);
+  private static final Log     LOG                 = ExoLogger.getLogger(NotificationSettingsUpgradePlugin.class);
 
-  private static final String EVENT_ADDED_PLUGIN_TYPE = "EventAddedNotificationPlugin";
-  private static final String EVENT_MODIFIED_PLUGIN_TYPE = "EventModifiedNotificationPlugin";
-  private static final String EVENT_CANCELED_PLUGIN_TYPE = "EventCanceledNotificationPlugin";
-  private static final String EVENT_REMINDER_PLUGIN_TYPE = "EventReminderNotificationPlugin";
-  private static final String CHAT_MENTION_PLUGIN_TYPE = "ChatMentionNotificationPlugin";
+  private static final String  NOTIFICATION_PLUGIN = "notification.upgrade.settings.plugin.types";
 
-  private ArrayList<String> pluginTypes = new ArrayList<>(Arrays.asList(EVENT_ADDED_PLUGIN_TYPE, EVENT_MODIFIED_PLUGIN_TYPE, EVENT_CANCELED_PLUGIN_TYPE, EVENT_REMINDER_PLUGIN_TYPE, CHAT_MENTION_PLUGIN_TYPE));
+  private SettingService       settingService;
 
-  private SettingService settingService;
-
-  private UserSettingService userSettingService;
+  private UserSettingService   userSettingService;
 
   private PluginSettingService pluginSettingService;
 
   private EntityManagerService entityManagerService;
+
+  private String               notificationPluginTypes;
 
   public NotificationSettingsUpgradePlugin(SettingService settingService,
                                            UserSettingService userSettingService,
@@ -47,11 +42,15 @@ public class NotificationSettingsUpgradePlugin extends UpgradeProductPlugin {
     this.userSettingService = userSettingService;
     this.pluginSettingService = pluginSettingService;
     this.entityManagerService = entityManagerService;
+    if (initParams.containsKey(NOTIFICATION_PLUGIN)) {
+      notificationPluginTypes = initParams.getValueParam(NOTIFICATION_PLUGIN).getValue();
+    }
   }
 
   @Override
   public void processUpgrade(String oldVersion, String newVersion) {
     ExoContainer currentContainer = ExoContainerContext.getCurrentContainer();
+    List<String> pluginTypes = Arrays.asList(notificationPluginTypes.replace("\n", "").replaceAll("\\s", "").split(","));
 
     for (String pluginType : pluginTypes) {
       int pageSize = 20;

--- a/data-upgrade-notifications/src/main/resources/conf/portal/configuration.xml
+++ b/data-upgrade-notifications/src/main/resources/conf/portal/configuration.xml
@@ -42,17 +42,26 @@
         <value-param>
           <name>plugin.upgrade.execute.once</name>
           <description>Execute this upgrade plugin only once</description>
-          <value>true</value>
+          <value>false</value>
         </value-param>
         <value-param>
           <name>plugin.upgrade.target.version</name>
           <description>Target version of the plugin</description>
-          <value>6.2.x</value>
+          <value>6.3.0</value>
         </value-param>
         <value-param>
           <name>plugin.upgrade.async.execution</name>
           <description>Execute this upgrade asynchronously</description>
           <value>true</value>
+        </value-param>
+        <value-param>
+          <name>notification.upgrade.settings.plugin.types</name>
+          <description>Execute this notification plugin Types</description>
+          <value>EventAddedNotificationPlugin, EventModifiedNotificationPlugin, EventCanceledNotificationPlugin,
+            EventReminderNotificationPlugin, VoteNotificationPlugin, EventReplyNotificationPlugin,
+            DatePollNotificationPlugin, ChatMentionNotificationPlugin, PublishNewsNotificationPlugin,
+            MfaAdminRevocationRequestPlugin, MentionInNewsNotificationPlugin, EditWikiNotificationPlugin
+          </value>
         </value-param>
       </init-params>
     </component-plugin>

--- a/data-upgrade-packaging/pom.xml
+++ b/data-upgrade-packaging/pom.xml
@@ -64,6 +64,10 @@
       <groupId>${project.groupId}</groupId>
       <artifactId>data-upgrade-app-registry</artifactId>
     </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>data-upgrade-notifications</artifactId>
+    </dependency>
 
     <!-- Transitive dependencies provided by eXo : set to provided -->
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <module>data-upgrade-navigations</module>
     <module>data-upgrade-app-registry</module>
     <module>data-upgrade-dlp</module>
-    <module>data-upgrade-portal-rdbms</module>
+    <module>data-upgrade-notifications</module>
     <module>data-upgrade-packaging</module>
   </modules>
   <properties>
@@ -139,6 +139,11 @@
       <dependency>
         <groupId>${project.groupId}</groupId>
         <artifactId>data-upgrade-app-registry</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>${project.groupId}</groupId>
+        <artifactId>data-upgrade-notifications</artifactId>
         <version>${project.version}</version>
       </dependency>
       <dependency>


### PR DESCRIPTION
**Problem:**  After migration from 6.1.x to 6.3.x, the new notifications types settings of agenda, notes, news, security plugins coming from 6.2.x are not activated by default.
**Solution:**  We make the old plugin NotificationSettingsUpgradePlugin implemented for agenda and chat notification types settings generic in order to consider any newly implemented notification types (the notifications coming from 6.2.x). The UP should be always executed not only once in order to not miss any newly implemented notification type.