### PR TITLE
Task-41630: Fix NotificationSettingsUpgradePlugin product.group.id

### DIFF
--- a/data-upgrade-notifications/src/main/resources/conf/portal/configuration.xml
+++ b/data-upgrade-notifications/src/main/resources/conf/portal/configuration.xml
@@ -32,7 +32,7 @@
         <value-param>
           <name>product.group.id</name>
           <description>The groupId of the product</description>
-          <value>org.exoplatform.portal</value>
+          <value>org.exoplatform.platform</value>
         </value-param>
         <value-param>
           <name>plugin.execution.order</name>


### PR DESCRIPTION
Prior to this change, NotificationSettingsUpgradePlugin is ignored when upgrading to 6.3.x due to product.group.id. After this change, product.group.id is set to org.exoplatform.platform in order to execute NotificationSettingsUpgradePlugin when upgrading to 6.3.x