### PR TITLE
Task-41630: Enable NotificationSettingsUpgradePlugin UP

### DIFF
--- a/data-upgrade-notifications/src/main/resources/conf/portal/configuration.xml
+++ b/data-upgrade-notifications/src/main/resources/conf/portal/configuration.xml
@@ -21,7 +21,7 @@
 -->
 <configuration xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.exoplatform.org/xml/ns/kernel_1_3.xsd http://www.exoplatform.org/xml/ns/kernel_1_3.xsd" xmlns="http://www.exoplatform.org/xml/ns/kernel_1_3.xsd">
 
-  <!--external-component-plugins>
+  <external-component-plugins>
     <target-component>org.exoplatform.commons.upgrade.UpgradeProductService</target-component>
     <component-plugin>
       <name>NotificationSettingsUpgradePlugin</name>
@@ -47,7 +47,7 @@
         <value-param>
           <name>plugin.upgrade.target.version</name>
           <description>Target version of the plugin</description>
-          <value>6.2.0</value>
+          <value>6.2.1</value>
         </value-param>
         <value-param>
           <name>plugin.upgrade.async.execution</name>
@@ -65,6 +65,6 @@
         </value-param>
       </init-params>
     </component-plugin>
-  </external-component-plugins-->
+  </external-component-plugins>
 </configuration>
 


### PR DESCRIPTION

Prior to this change, the NotificationSettingsUpgradePlugin UP is disabled since it is not well executed asynchronously which causes a problem of server startup with a big number of users. After this change, the NotificationSettingsUpgradePlugin UP is enabled again since the problem of UP asynchronous execution is fixed.