### PR TITLE
Task-48219 - Error during server startup about upgrade plugin DlpFold…

### DIFF
--- a/data-upgrade-dlp/src/main/java/org/exoplatform/migration/dlp/DlpFolderAndDriveMigration.java
+++ b/data-upgrade-dlp/src/main/java/org/exoplatform/migration/dlp/DlpFolderAndDriveMigration.java
@@ -42,12 +42,10 @@ public class DlpFolderAndDriveMigration extends UpgradeProductPlugin {
   public DlpFolderAndDriveMigration(InitParams initParams,
                                     SettingService settingService,
                                     RepositoryService repositoryService,
-                                    ManageDriveService manageDriveService,
-                                    SessionProviderService sessionProviderService) {
+                                    ManageDriveService manageDriveService) {
     super(settingService, initParams);
     this.repositoryService = repositoryService;
     this.manageDriveService = manageDriveService;
-    this.sessionProviderService = sessionProviderService;
     if (initParams.containsKey(OLD_NODE_PATH)) {
       oldNodePath = initParams.getValueParam(OLD_NODE_PATH).getValue();
     }
@@ -68,7 +66,7 @@ public class DlpFolderAndDriveMigration extends UpgradeProductPlugin {
     }
     SessionProvider sessionProvider = null;
     try {
-      sessionProvider = sessionProviderService.getSystemSessionProvider(null);
+      sessionProvider = SessionProvider.createSystemProvider();
       Session session = sessionProvider.getSession(WORKSPACE_COLLABORATION, repositoryService.getCurrentRepository());
       if (session.itemExists(oldNodePath)) {
         long startupTime = System.currentTimeMillis();

--- a/data-upgrade-dlp/src/test/java/org/exoplatform/migration/dlp/DlpFolderAndDriveMigrationTest.java
+++ b/data-upgrade-dlp/src/test/java/org/exoplatform/migration/dlp/DlpFolderAndDriveMigrationTest.java
@@ -10,7 +10,6 @@ import org.exoplatform.services.cms.drives.DriveData;
 import org.exoplatform.services.cms.drives.ManageDriveService;
 import org.exoplatform.services.jcr.RepositoryService;
 import org.exoplatform.services.jcr.core.ManageableRepository;
-import org.exoplatform.services.jcr.ext.app.SessionProviderService;
 import org.exoplatform.services.jcr.ext.common.SessionProvider;
 import org.junit.Test;
 
@@ -18,6 +17,8 @@ import org.exoplatform.container.xml.InitParams;
 import org.exoplatform.container.xml.ValueParam;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
 import javax.jcr.Node;
@@ -26,6 +27,7 @@ import javax.jcr.Session;
 import javax.jcr.Workspace;
 
 @RunWith(PowerMockRunner.class)
+@PrepareForTest(SessionProvider.class)
 public class DlpFolderAndDriveMigrationTest {
 
   @Mock
@@ -33,9 +35,6 @@ public class DlpFolderAndDriveMigrationTest {
 
   @Mock
   ManageDriveService manageDriveService;
-
-  @Mock
-  SessionProviderService       sessionProviderService;
 
   @Mock
   ManageableRepository         repository;
@@ -68,8 +67,10 @@ public class DlpFolderAndDriveMigrationTest {
     DriveData driveQuarantine = mock(DriveData.class);
     DriveData driveSecurity = mock(DriveData.class);
 
+    PowerMockito.mockStatic(SessionProvider.class);
+    when(SessionProvider.createSystemProvider()).thenReturn(sessionProvider);
+
     Workspace workspace = mock(Workspace.class);
-    when(sessionProviderService.getSystemSessionProvider(any())).thenReturn(sessionProvider);
     when(repositoryService.getCurrentRepository()).thenReturn(repository);
     when(sessionProvider.getSession(any(), any())).thenReturn(session);
     when(session.getWorkspace()).thenReturn(workspace);
@@ -90,8 +91,7 @@ public class DlpFolderAndDriveMigrationTest {
     DlpFolderAndDriveMigration dlpFolderAndDriveMigration = new DlpFolderAndDriveMigration(initParams,
                                                                                            settingService,
                                                                                            repositoryService,
-                                                                                           manageDriveService,
-                                                                                           sessionProviderService);
+                                                                                           manageDriveService);
     dlpFolderAndDriveMigration.processUpgrade(null, null);
     assertEquals(2, dlpFolderAndDriveMigration.getNodesMovedCount());
 


### PR DESCRIPTION
…erAndDriveMigration

Before this fix, with a fresh server, there is an error in console when the upgradeplugin DlpFolderAndDriveMigration runs :
java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
    at java.base/java.lang.Thread.run(Thread.java:829)
Caused by: java.lang.IllegalStateException: Session provider already closed

This change modify the way we get SessionProvider by using createSystemProvider (which create new session), instead of using SessionProviderService