### PR TITLE
Task-51831: Fix latest news and slider CLV portlets displaying after refactoring

### DIFF
--- a/data-upgrade-ecms/src/main/resources/conf/portal/configuration.xml
+++ b/data-upgrade-ecms/src/main/resources/conf/portal/configuration.xml
@@ -78,7 +78,7 @@
         <value-param>
           <name>plugin.upgrade.target.version</name>
           <description>Target version of the plugin</description>
-          <value>6.2.0</value>
+          <value>6.3.0</value>
         </value-param>
       </init-params>
     </component-plugin>


### PR DESCRIPTION

Prior to this change, after working on refactoring via https://community.exoplatform.com/portal/dw/tasks/taskDetail/49906, the latest news and slider portlets are not more displayed on snapshot page.
This is due to a modification done on the corresponding templates which is not not applied on full data servers (tribe, client instances), in fact the upgrade plugin WCMTemplateUpgradePlugin is not executed on the 6.3.0 target version. After this change, the target version of WCMTemplateUpgradePlugin is set to 6.3.0 to ensure its execution.