### PR TITLE
Task-52442: Implement DeleteNewsTargets UpgradePlugin

### DIFF
--- a/data-upgrade-news/src/main/java/org/exoplatform/news/upgrade/targets/DeleteNewsTargetsUpgradePlugin.java
+++ b/data-upgrade-news/src/main/java/org/exoplatform/news/upgrade/targets/DeleteNewsTargetsUpgradePlugin.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2021 eXo Platform SAS.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.exoplatform.news.upgrade.targets;
+
+import java.util.List;
+
+import org.exoplatform.commons.upgrade.UpgradeProductPlugin;
+import org.exoplatform.container.xml.InitParams;
+import org.exoplatform.news.rest.NewsTargetingEntity;
+import org.exoplatform.news.service.NewsTargetingService;
+import org.exoplatform.services.log.ExoLogger;
+import org.exoplatform.services.log.Log;
+
+/**
+ * Created by The eXo Platform SAS Author : Ayoub Zayati December 22, 2021 
+ * This plugin will be executed in order to delete created news targets without labels
+ */
+public class DeleteNewsTargetsUpgradePlugin extends UpgradeProductPlugin {
+
+  private static final Log     log = ExoLogger.getLogger(DeleteNewsTargetsUpgradePlugin.class.getName());
+
+  private NewsTargetingService newsTargetingService;
+
+  private int                  newsTargetsCount;
+
+  public DeleteNewsTargetsUpgradePlugin(InitParams initParams, NewsTargetingService newsTargetingService) {
+    super(initParams);
+    this.newsTargetingService = newsTargetingService;
+  }
+
+  @Override
+  public void processUpgrade(String oldVersion, String newVersion) {
+    long startupTime = System.currentTimeMillis();
+    log.info("Start upgrade of news targets");
+    List<NewsTargetingEntity> newsTargets = newsTargetingService.getTargets();
+    for (NewsTargetingEntity newsTarget : newsTargets) {
+      newsTargetingService.deleteTargetByName(newsTarget.getName());
+      newsTargetsCount++;
+    }
+    log.info("End upgrade of '{}' news targets. It took {} ms", newsTargetsCount, (System.currentTimeMillis() - startupTime));
+  }
+
+  /**
+   * @return the newsTargetsCount
+   */
+  public int getNewsTargetsCount() {
+    return newsTargetsCount;
+  }
+
+}

--- a/data-upgrade-news/src/main/resources/conf/portal/configuration.xml
+++ b/data-upgrade-news/src/main/resources/conf/portal/configuration.xml
@@ -118,6 +118,39 @@
         </value-param>
       </init-params>
     </component-plugin>
+    <component-plugin profiles="news">
+      <name>DeleteNewsTargetsUpgradePlugin</name>
+      <set-method>addUpgradePlugin</set-method>
+      <type>org.exoplatform.news.upgrade.targets.DeleteNewsTargetsUpgradePlugin</type>
+      <description>Delete created news targets without labels</description>
+      <init-params>
+        <value-param>
+          <name>product.group.id</name>
+          <description>The groupId of the product</description>
+          <value>org.exoplatform.platform</value>
+        </value-param>
+        <value-param>
+          <name>plugin.execution.order</name>
+          <description>The plugin execution order</description>
+          <value>2</value>
+        </value-param>
+        <value-param>
+          <name>plugin.upgrade.execute.once</name>
+          <description>Execute this upgrade plugin only once</description>
+          <value>true</value>
+        </value-param>
+        <value-param>
+          <name>plugin.upgrade.async.execution</name>
+          <description>The plugin will be executed in an asynchronous mode</description>
+          <value>true</value>
+        </value-param>
+        <value-param>
+          <name>plugin.upgrade.target.version</name>
+          <description>Target version of the plugin</description>
+          <value>6.3.0-20211222</value>
+        </value-param>
+      </init-params>
+    </component-plugin>
   </external-component-plugins>
 </configuration>
 

--- a/data-upgrade-news/src/test/java/org/exoplatform/news/upgrade/targets/DeleteNewsTargetsUpgradePluginTest.java
+++ b/data-upgrade-news/src/test/java/org/exoplatform/news/upgrade/targets/DeleteNewsTargetsUpgradePluginTest.java
@@ -1,0 +1,55 @@
+package org.exoplatform.news.upgrade.targets;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import org.exoplatform.container.xml.InitParams;
+import org.exoplatform.container.xml.ValueParam;
+import org.exoplatform.news.rest.NewsTargetingEntity;
+import org.exoplatform.news.service.NewsTargetingService;
+
+@RunWith(PowerMockRunner.class)
+public class DeleteNewsTargetsUpgradePluginTest {
+
+  @Mock
+  NewsTargetingService newsTargetingService;
+  
+  @Test
+  public void testNewsDeleteTargetsMigration() throws Exception {
+    InitParams initParams = new InitParams();
+
+    ValueParam valueParam = new ValueParam();
+    valueParam.setName("product.group.id");
+    valueParam.setValue("org.exoplatform.addons.platform");
+    initParams.addParameter(valueParam);
+    
+    NewsTargetingEntity newsTarget1 = new NewsTargetingEntity();
+    newsTarget1.setName("target1");
+    newsTarget1.setName("target 1");
+    
+    NewsTargetingEntity newsTarget2 = new NewsTargetingEntity();
+    newsTarget1.setName("target2");
+    newsTarget1.setName("target 2");
+    
+    List<NewsTargetingEntity> newsTargets = new ArrayList<>();
+    newsTargets.add(newsTarget1);
+    newsTargets.add(newsTarget2);
+
+    when(newsTargetingService.getTargets()).thenReturn(newsTargets);
+    DeleteNewsTargetsUpgradePlugin deleteNewsTargetsUpgradePlugin = new DeleteNewsTargetsUpgradePlugin(initParams, newsTargetingService);
+    deleteNewsTargetsUpgradePlugin.processUpgrade(null, null);
+    verify(newsTargetingService, times(2)).deleteTargetByName(any());
+    assertEquals(2, deleteNewsTargetsUpgradePlugin.getNewsTargetsCount());
+  }
+}


### PR DESCRIPTION
Prior to this change, news targets are already created without labels, thus we need to implement an upgrade plugin in order to delete the old created news targets and allow creating
the right one with label and referenced properties.