### PR TITLE
MAINT-45435: Implement an upgrade plugin to remove portlet preferences from popular spaces portlet settings

### DIFF
--- a/data-upgrade-pages/src/main/java/org/exoplatform/migration/PopularSpacesRemovePreferences.java
+++ b/data-upgrade-pages/src/main/java/org/exoplatform/migration/PopularSpacesRemovePreferences.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (C) 2021 eXo Platform SAS.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.exoplatform.migration;
+
+import org.exoplatform.commons.persistence.impl.EntityManagerService;
+import org.exoplatform.commons.upgrade.UpgradeProductPlugin;
+import org.exoplatform.container.PortalContainer;
+import org.exoplatform.container.component.RequestLifeCycle;
+import org.exoplatform.container.xml.InitParams;
+import org.exoplatform.services.log.ExoLogger;
+import org.exoplatform.services.log.Log;
+
+import javax.persistence.EntityManager;
+import javax.persistence.Query;
+
+public class PopularSpacesRemovePreferences extends UpgradeProductPlugin {
+
+    private static final Log LOG                              = ExoLogger.getExoLogger(PopularSpacesRemovePreferences.class);
+
+    private static final String APPLICATION_CONTENT_ID        = "gamification-portlets/PopularSpaces";
+
+    private EntityManagerService entityManagerService;
+
+    private boolean portletUpdated = false;
+
+    public PopularSpacesRemovePreferences(EntityManagerService entityManagerService, InitParams initParams) {
+        super(initParams);
+        this.entityManagerService = entityManagerService;
+    }
+
+    @Override
+    public void processUpgrade(String oldVersion, String newVersion) {
+        LOG.info("Start upgrade of Popular spaces portlet: {}", APPLICATION_CONTENT_ID);
+        long startupTime = System.currentTimeMillis();
+        boolean transactionStarted = false;
+
+        PortalContainer container = PortalContainer.getInstance();
+        RequestLifeCycle.begin(container);
+        EntityManager entityManager = this.entityManagerService.getEntityManager();
+        try {
+            if (!entityManager.getTransaction().isActive()) {
+                entityManager.getTransaction().begin();
+                transactionStarted = true;
+            }
+            String sqlString = "UPDATE PORTAL_WINDOWS w SET w.CUSTOMIZATION = NULL WHERE w.CONTENT_ID = '" + APPLICATION_CONTENT_ID + "'";
+            Query nativeQuery = entityManager.createNativeQuery(sqlString);
+            int update = nativeQuery.executeUpdate();
+            if (update != 0) {
+                LOG.info("Popular spaces portlet preferences settings removed successfully");
+                this.portletUpdated = true;
+            }
+            if (transactionStarted && entityManager.getTransaction().isActive()) {
+                entityManager.getTransaction().commit();
+                entityManager.flush();
+            }
+        } catch (Exception e) {
+            if (transactionStarted && entityManager.getTransaction().isActive() && entityManager.getTransaction().getRollbackOnly()) {
+                entityManager.getTransaction().rollback();
+            }
+        } finally {
+            RequestLifeCycle.end();
+        }
+        LOG.info("End upgrade of Popular spaces portlet. It took {} ms", (System.currentTimeMillis() - startupTime));
+    }
+
+    public boolean isPortletUpdated() {
+        return portletUpdated;
+    }
+}

--- a/data-upgrade-pages/src/main/resources/conf/portal/configuration.xml
+++ b/data-upgrade-pages/src/main/resources/conf/portal/configuration.xml
@@ -439,5 +439,38 @@
         </value-param>
       </init-params>
     </component-plugin>
+    <component-plugin profiles="gamification">
+      <name>PopularSpacesRemovePreferences</name>
+      <set-method>addUpgradePlugin</set-method>
+      <type>org.exoplatform.migration.PopularSpacesRemovePreferences</type>
+      <description>Remove portlet preferences option from popular spaces portlet settings</description>
+      <init-params>
+        <value-param>
+          <name>product.group.id</name>
+          <description>The groupId of the product</description>
+          <value>org.exoplatform.platform</value>
+        </value-param>
+        <value-param>
+          <name>plugin.upgrade.target.version</name>
+          <description>The plugin target version of selected groupId</description>
+          <value>6.3.0</value>
+        </value-param>
+        <value-param>
+          <name>plugin.execution.order</name>
+          <description>The plugin execution order</description>
+          <value>10</value>
+        </value-param>
+        <value-param>
+          <name>plugin.upgrade.execute.once</name>
+          <description>The plugin must be executed only once</description>
+          <value>true</value>
+        </value-param>
+        <value-param>
+          <name>plugin.upgrade.async.execution</name>
+          <description>The plugin will be executed in an asynchronous mode</description>
+          <value>true</value>
+        </value-param>
+      </init-params>
+    </component-plugin>
   </external-component-plugins>
 </configuration>

--- a/data-upgrade-pages/src/test/java/org/exoplatform/migration/PopularSpacesRemovePreferencesTest.java
+++ b/data-upgrade-pages/src/test/java/org/exoplatform/migration/PopularSpacesRemovePreferencesTest.java
@@ -1,0 +1,92 @@
+package org.exoplatform.migration;
+
+import org.exoplatform.commons.persistence.impl.EntityManagerService;
+import org.exoplatform.container.PortalContainer;
+import org.exoplatform.container.component.RequestLifeCycle;
+import org.exoplatform.container.xml.InitParams;
+import org.exoplatform.container.xml.ValueParam;
+import org.exoplatform.portal.config.DataStorage;
+import org.exoplatform.portal.config.model.*;
+import org.exoplatform.portal.mop.Utils;
+import org.exoplatform.portal.mop.page.PageContext;
+import org.exoplatform.portal.mop.page.PageService;
+import org.exoplatform.portal.mop.page.PageState;
+import org.exoplatform.portal.pom.data.ModelDataStorage;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+
+import static org.junit.Assert.*;
+
+public class PopularSpacesRemovePreferencesTest {
+
+    private static final String    SITE_TYPE           = PortalConfig.PORTAL_TYPE;
+    private static final String    SITE_NAME           = "testSite";
+
+
+    protected PortalContainer container;
+    protected PageService pageService;
+    protected DataStorage dataStorage;
+    protected EntityManagerService entityManagerService;
+    protected Page testPage;
+
+
+    @Before
+    public void setUp() {
+        container = PortalContainer.getInstance();
+        pageService = container.getComponentInstanceOfType(PageService.class);
+        dataStorage = container.getComponentInstanceOfType(DataStorage.class);
+        entityManagerService = container.getComponentInstanceOfType(EntityManagerService.class);
+    }
+
+    @Test
+    public void testUpgradePopularSpacesPortlet() throws Exception {
+        InitParams initParams = new InitParams();
+
+        ValueParam valueParam = new ValueParam();
+        valueParam.setName("product.group.id");
+        valueParam.setValue("org.exoplatform.platform");
+        initParams.addParameter(valueParam);
+
+        RequestLifeCycle.begin(container);
+        PortalConfig portalConfig = dataStorage.getPortalConfig(SITE_TYPE, SITE_NAME);
+        if (portalConfig == null) {
+            portalConfig = new PortalConfig(SITE_TYPE, SITE_NAME);
+            dataStorage.create(portalConfig);
+        }
+        testPage = createPage("Popular spaces", "gamification-portlets/PopularSpaces");
+        PopularSpacesRemovePreferences preferences = new PopularSpacesRemovePreferences(entityManagerService, initParams);
+        assertFalse(preferences.isPortletUpdated());
+        preferences.processUpgrade(null, null);
+        assertTrue(preferences.isPortletUpdated());
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        pageService.destroyPage(testPage.getPageKey());
+        RequestLifeCycle.end();
+    }
+
+    private Page createPage(String pageName, String contentId) throws Exception {
+        Page page = new Page(SITE_TYPE, SITE_NAME, pageName);
+        page.setAccessPermissions(new String[] { "Everyone" });
+        ArrayList<ModelObject> children = new ArrayList<>();
+        page.setChildren(children);
+        Application<?> app = Application.createPortletApplication();
+        children.add(app);
+        app.setState(new TransientApplicationState(contentId, "test custom preferences"));
+        app.setTheme("theme");
+        app.setTitle("title");
+        app.setAccessPermissions(new String[] { "Everyone" });
+        app.setStorageName("storage");
+        PageState pageState = Utils.toPageState(page);
+        pageService.savePage(new PageContext(page.getPageKey(), pageState));
+        dataStorage.save(page);
+
+        return page;
+    }
+
+}


### PR DESCRIPTION
ISSUE: The migrated version to 6.3 before removing the portlet preferences form popular spaces still display the option in the portlet settings
FIX: Implement an upgrade plugin to remove the option