### PR TITLE
MAINT-52325: Implement an upgrade plugin to fix the viewsCount of old news articles

### DIFF
--- a/data-upgrade-news/src/main/java/org/exoplatform/news/upgrade/jcr/NewsArticlesViewsCountUpgrade.java
+++ b/data-upgrade-news/src/main/java/org/exoplatform/news/upgrade/jcr/NewsArticlesViewsCountUpgrade.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (C) 2021 eXo Platform SAS.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.exoplatform.news.upgrade.jcr;
+
+import org.exoplatform.commons.upgrade.UpgradeProductPlugin;
+import org.exoplatform.container.xml.InitParams;
+import org.exoplatform.services.jcr.RepositoryService;
+import org.exoplatform.services.jcr.ext.app.SessionProviderService;
+import org.exoplatform.services.jcr.ext.common.SessionProvider;
+import org.exoplatform.services.log.ExoLogger;
+import org.exoplatform.services.log.Log;
+import org.exoplatform.services.wcm.core.NodetypeConstant;
+
+import javax.jcr.Node;
+import javax.jcr.NodeIterator;
+import javax.jcr.Session;
+import javax.jcr.query.Query;
+import javax.jcr.query.QueryManager;
+
+public class NewsArticlesViewsCountUpgrade extends UpgradeProductPlugin {
+
+    private static final Log LOG                           = ExoLogger.getLogger(NewsArticlesViewsCountUpgrade.class.getName());
+
+    private RepositoryService repositoryService;
+    private SessionProviderService sessionProviderService;
+
+    private int updatedNodes                              = 0 ;
+
+    private static final String EXO_NEWS_VIEWERS          = "exo:viewers";
+    private static final String EXO_NEWS_VIEWS_COUNT      = "exo:viewsCount";
+
+    public NewsArticlesViewsCountUpgrade(InitParams initParams,
+                                         RepositoryService repositoryService,
+                                         SessionProviderService sessionProviderService) {
+        super(initParams);
+        this.repositoryService = repositoryService;
+        this.sessionProviderService = sessionProviderService;
+    }
+
+    public int getUpdatedNodes() {
+        return updatedNodes;
+    }
+
+    @Override
+    public void processUpgrade(String oldVersion, String newVersion) {
+        long startupTime = System.currentTimeMillis();
+        LOG.info("Start upgrade of news articles viewsCount");
+        SessionProvider sessionProvider = null;
+        try {
+            sessionProvider = sessionProviderService.getSystemSessionProvider(null);
+            Session session = sessionProvider.getSession(
+                    repositoryService.getCurrentRepository()
+                            .getConfiguration()
+                            .getDefaultWorkspaceName(),
+                    repositoryService.getCurrentRepository());
+            String queryString = "SELECT * FROM exo:news WHERE jcr:path LIKE '/Groups/spaces/%/News/%'";
+            QueryManager queryManager = session.getWorkspace().getQueryManager();
+            Query query = queryManager.createQuery(queryString, Query.SQL);
+
+            NodeIterator newsIterator = query.execute().getNodes();
+            while (newsIterator.hasNext()) {
+                Node news = newsIterator.nextNode();
+                String newsTitle = news.getProperty(NodetypeConstant.EXO_TITLE).getValue().getString();
+                if (news.hasProperty(EXO_NEWS_VIEWS_COUNT) && news.hasProperty(EXO_NEWS_VIEWERS)) {
+                    long viewsCount = news.getProperty(EXO_NEWS_VIEWERS).getValue().getString().split(",").length;
+                    long oldViewsCount = news.getProperty(EXO_NEWS_VIEWS_COUNT).getValue().getLong();
+                    if (viewsCount > oldViewsCount) {
+                        news.setProperty(EXO_NEWS_VIEWS_COUNT, viewsCount);
+                        news.save();
+                        LOG.info("viewsCount of article {} has been updated: {}", newsTitle, viewsCount);
+                        updatedNodes++;
+                    }
+                }
+            }
+            LOG.info("End upgrade of news articles viewsCount, {} articles were successfully updated. It took {} ms",
+                    updatedNodes, (System.currentTimeMillis() - startupTime));
+
+        } catch (Exception e) {
+            LOG.error("An error occurred when upgrading news article viewsCount:", e);
+
+        } finally {
+            if (sessionProvider != null) {
+                sessionProvider.close();
+            }
+        }
+    }
+}

--- a/data-upgrade-news/src/main/resources/conf/portal/configuration.xml
+++ b/data-upgrade-news/src/main/resources/conf/portal/configuration.xml
@@ -151,6 +151,39 @@
         </value-param>
       </init-params>
     </component-plugin>
+    <component-plugin profiles="news">
+      <name>NewsArticlesViewsCountUpgrade</name>
+      <set-method>addUpgradePlugin</set-method>
+      <type>org.exoplatform.news.upgrade.jcr.NewsArticlesViewsCountUpgrade</type>
+      <description>Fix Incorrect viewsCount of news articles nodes</description>
+      <init-params>
+        <value-param>
+          <name>product.group.id</name>
+          <description>The groupId of the product</description>
+          <value>org.exoplatform.ecms</value>
+        </value-param>
+        <value-param>
+          <name>plugin.execution.order</name>
+          <description>The plugin execution order</description>
+          <value>2</value>
+        </value-param>
+        <value-param>
+          <name>plugin.upgrade.execute.once</name>
+          <description>Execute this upgrade plugin only once</description>
+          <value>true</value>
+        </value-param>
+        <value-param>
+          <name>plugin.upgrade.async.execution</name>
+          <description>The plugin will be executed in an asynchronous mode</description>
+          <value>true</value>
+        </value-param>
+        <value-param>
+          <name>plugin.upgrade.target.version</name>
+          <description>Target version of the plugin</description>
+          <value>6.3.0</value>
+        </value-param>
+      </init-params>
+    </component-plugin>
   </external-component-plugins>
 </configuration>
 

--- a/data-upgrade-news/src/test/java/org/exoplatform/news/upgrade/jcr/NewsArticlesViewsCountUpgradeTest.java
+++ b/data-upgrade-news/src/test/java/org/exoplatform/news/upgrade/jcr/NewsArticlesViewsCountUpgradeTest.java
@@ -1,0 +1,97 @@
+package org.exoplatform.news.upgrade.jcr;
+
+import org.exoplatform.container.xml.InitParams;
+import org.exoplatform.container.xml.ValueParam;
+import org.exoplatform.services.jcr.RepositoryService;
+import org.exoplatform.services.jcr.config.RepositoryEntry;
+import org.exoplatform.services.jcr.core.ManageableRepository;
+import org.exoplatform.services.jcr.ext.app.SessionProviderService;
+import org.exoplatform.services.jcr.ext.common.SessionProvider;
+import org.exoplatform.services.jcr.ext.hierarchy.NodeHierarchyCreator;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import javax.jcr.*;
+import javax.jcr.query.Query;
+import javax.jcr.query.QueryManager;
+import javax.jcr.query.QueryResult;
+
+import static org.junit.Assert.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@RunWith(PowerMockRunner.class)
+public class NewsArticlesViewsCountUpgradeTest {
+
+    @Mock
+    private RepositoryService repositoryService;
+
+    @Mock
+    private SessionProviderService sessionProviderService;
+
+    @Mock
+    private ManageableRepository repository;
+
+    @Mock
+    private RepositoryEntry repositoryEntry;
+
+    @Mock
+    private SessionProvider sessionProvider;
+
+    @Mock
+    private Session session;
+
+    @Mock
+    private NodeIterator nodeIterator;
+
+    @Mock
+    private QueryManager queryManager;
+
+
+    @Test
+    public void testNewsArticleViewsCountUpgrade() throws RepositoryException {
+        InitParams initParams = new InitParams();
+
+        ValueParam valueParam = new ValueParam();
+        valueParam.setName("product.group.id");
+        valueParam.setValue("org.exoplatform.platform");
+        initParams.addParameter(valueParam);
+
+        Node testNode = mock(Node.class);
+        Property property = mock(Property.class);
+        Value value = mock(Value.class);
+        Workspace workspace = mock(Workspace.class);
+        Query query = mock(Query.class);
+        QueryResult queryResult = mock(QueryResult.class);
+
+        when(sessionProviderService.getSystemSessionProvider(any())).thenReturn(sessionProvider);
+        when(repositoryService.getCurrentRepository()).thenReturn(repository);
+        when(repository.getConfiguration()).thenReturn(repositoryEntry);
+        when(repositoryEntry.getDefaultWorkspaceName()).thenReturn("collaboration");
+        when(sessionProvider.getSession(any(), any())).thenReturn(session);
+        when(nodeIterator.hasNext()).thenReturn(true, true, false);
+        when(queryManager.createQuery(anyString(),any())).thenReturn(query);
+        when(query.execute()).thenReturn(queryResult);
+        when(queryResult.getNodes()).thenReturn(nodeIterator);
+        when(session.getWorkspace()).thenReturn(workspace);
+        when(workspace.getQueryManager()).thenReturn(queryManager);
+        when(nodeIterator.nextNode()).thenReturn(testNode);
+        when(testNode.hasProperty("exo:viewsCount")).thenReturn(true);
+        when(testNode.hasProperty("exo:viewers")).thenReturn(true);
+        when(testNode.getProperty(anyString())).thenReturn(property);
+        when(testNode.getProperty("exo:viewers").getValue()).thenReturn(value);
+        when(testNode.getProperty("exo:viewers").getValue().getString()).thenReturn("user1,user2,user3");
+
+        NewsArticlesViewsCountUpgrade plugin = new NewsArticlesViewsCountUpgrade(initParams,
+                                                                                 repositoryService,
+                                                                                 sessionProviderService);
+        plugin.processUpgrade(null,null);
+        assertEquals(2, plugin.getUpdatedNodes());
+    }
+}


### PR DESCRIPTION

ISSUE: Some articles are affected by an issue of incorrect viewsCount, the jcr nodes of these article have a wrong value of viewsCount property while the value of the viewers property is correct.
FIX: This fix is an upgrade plugin that  will use the value of viewers property to fix the viewsCount value.