### PR TITLE
Task-50194: Upgrade Plugin problem during migration

### DIFF
--- a/data-upgrade-pages/src/main/java/org/exoplatform/migration/PagesMigration.java
+++ b/data-upgrade-pages/src/main/java/org/exoplatform/migration/PagesMigration.java
@@ -97,8 +97,8 @@ public class PagesMigration extends UpgradeProductPlugin {
           transactionStarted = true;
         }
 
-        String sqlString = "UPDATE PORTAL_WINDOWS w SET w.CONTENT_ID = '" + newApplicationReference
-            + "' WHERE w.CONTENT_ID = '" + oldApplicationReference + "' AND w.ID > 0;";
+        String sqlString = "UPDATE PORTAL_WINDOWS  SET CONTENT_ID = '" + newApplicationReference
+            + "' WHERE CONTENT_ID = '" + oldApplicationReference + "' AND ID > 0;";
         Query nativeQuery = entityManager.createNativeQuery(sqlString);
         this.pagesUpdatedCount = nativeQuery.executeUpdate();
         LOG.info("End upgrade of '{}' pages with application references '{}' to use application '{}'. It took {} ms",


### PR DESCRIPTION
Problem: During the migration from 6.0 to 6.1 using PostgreSQL, a log error message was appeared
Fix: I removed the alias from **PageMigration** because PostgreSQL can't support it