### PR TITLE
Task-54884 : External users receive notification of published news from a space of which they are not a member 

### DIFF
--- a/data-upgrade-users/src/main/java/org/exoplatform/migration/UserSetExternalInGateinPortal.java
+++ b/data-upgrade-users/src/main/java/org/exoplatform/migration/UserSetExternalInGateinPortal.java
@@ -1,6 +1,21 @@
+/*
+ * Copyright (C) 2022 eXo Platform SAS.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.exoplatform.migration;
 
-import org.exoplatform.commons.serialization.serial.ObjectReader;
 import org.exoplatform.commons.upgrade.UpgradeProductPlugin;
 import org.exoplatform.commons.utils.ListAccess;
 import org.exoplatform.container.ExoContainerContext;
@@ -11,7 +26,6 @@ import org.exoplatform.services.log.Log;
 import org.exoplatform.services.organization.Group;
 import org.exoplatform.services.organization.Membership;
 import org.exoplatform.services.organization.OrganizationService;
-import org.exoplatform.services.organization.User;
 import org.exoplatform.services.organization.UserProfile;
 
 import java.util.Arrays;

--- a/data-upgrade-users/src/main/java/org/exoplatform/migration/UserSetExternalInGateinPortal.java
+++ b/data-upgrade-users/src/main/java/org/exoplatform/migration/UserSetExternalInGateinPortal.java
@@ -1,0 +1,73 @@
+package org.exoplatform.migration;
+
+import org.exoplatform.commons.serialization.serial.ObjectReader;
+import org.exoplatform.commons.upgrade.UpgradeProductPlugin;
+import org.exoplatform.commons.utils.ListAccess;
+import org.exoplatform.container.ExoContainerContext;
+import org.exoplatform.container.component.RequestLifeCycle;
+import org.exoplatform.container.xml.InitParams;
+import org.exoplatform.services.log.ExoLogger;
+import org.exoplatform.services.log.Log;
+import org.exoplatform.services.organization.Group;
+import org.exoplatform.services.organization.Membership;
+import org.exoplatform.services.organization.OrganizationService;
+import org.exoplatform.services.organization.User;
+import org.exoplatform.services.organization.UserProfile;
+
+import java.util.Arrays;
+
+public class UserSetExternalInGateinPortal extends UpgradeProductPlugin {
+  private static final Log LOG = ExoLogger.getExoLogger(UsersLastLoginTimeMigration.class);
+
+  OrganizationService organizationService;
+  public UserSetExternalInGateinPortal(OrganizationService organizationService,InitParams initParams) {
+    super(initParams);
+    this.organizationService=organizationService;
+
+  }
+  @Override
+  public void processUpgrade(String oldVersion, String newVersion) {
+    LOG.info("Start upgrade process to add external info in gatein user profile");
+    long startupTime = System.currentTimeMillis();
+    try {
+      Group group = organizationService.getGroupHandler().findGroupById("/platform/externals");
+      ListAccess<Membership> externalsMemberships = organizationService.getMembershipHandler().findAllMembershipsByGroup(group);
+      int total = externalsMemberships.getSize();
+      LOG.info("Number of users to update : " + total);
+
+      int pageSize = 100;
+      int current=0;
+      while (current<total) {
+        RequestLifeCycle.begin(ExoContainerContext.getCurrentContainer());
+
+        Membership[] currentBatch = externalsMemberships.load(0,pageSize);
+        Arrays.stream(currentBatch).forEach(membership -> {
+          long startTimeForUser = System.currentTimeMillis();
+          String username = membership.getUserName();
+          try {
+            UserProfile profile = organizationService.getUserProfileHandler().findUserProfileByName(username);
+            if (profile==null) {
+              profile=organizationService.getUserProfileHandler().createUserProfileInstance(username);
+            }
+            profile.setAttribute(UserProfile.OTHER_KEYS[2],"true");
+            organizationService.getUserProfileHandler().saveUserProfile(profile,true);
+            LOG.debug("External info added in gatein profile for user {}, {}ms", username, System.currentTimeMillis() - startTimeForUser);
+          } catch (Exception e) {
+            LOG.error("Unable to get profile for user {}",username);
+          }
+        });
+        current=current+currentBatch.length;
+        LOG.info("Progession : {} users updated on {} total users. It tooks {}ms",
+                 current,
+                 total,
+                 System.currentTimeMillis() - startupTime);
+
+        RequestLifeCycle.end();
+
+
+      }
+    } catch (Exception e) {
+      LOG.error("Unable to find group externals");
+    }
+  }
+}

--- a/data-upgrade-users/src/main/java/org/exoplatform/migration/UserSetExternalInGateinPortal.java
+++ b/data-upgrade-users/src/main/java/org/exoplatform/migration/UserSetExternalInGateinPortal.java
@@ -31,7 +31,7 @@ import org.exoplatform.services.organization.UserProfile;
 import java.util.Arrays;
 
 public class UserSetExternalInGateinPortal extends UpgradeProductPlugin {
-  private static final Log LOG = ExoLogger.getExoLogger(UsersLastLoginTimeMigration.class);
+  private static final Log LOG = ExoLogger.getExoLogger(UserSetExternalInGateinPortal.class);
 
   OrganizationService organizationService;
   public UserSetExternalInGateinPortal(OrganizationService organizationService,InitParams initParams) {

--- a/data-upgrade-users/src/main/resources/conf/portal/configuration.xml
+++ b/data-upgrade-users/src/main/resources/conf/portal/configuration.xml
@@ -74,7 +74,7 @@
           <name>plugin.upgrade.target.version</name>
           <description>The plugin target version (will not be executed if previous version is equal or higher than 6.3.1)
           </description>
-          <value>6.3.x-maintenance-SNAPSHOT</value>
+          <value>6.3.0</value>
         </value-param>
         <value-param>
           <name>plugin.execution.order</name>

--- a/data-upgrade-users/src/main/resources/conf/portal/configuration.xml
+++ b/data-upgrade-users/src/main/resources/conf/portal/configuration.xml
@@ -57,4 +57,42 @@
     </component-plugin>
   </external-component-plugins>
 
+  <external-component-plugins>
+    <target-component>org.exoplatform.commons.upgrade.UpgradeProductService</target-component>
+    <component-plugin>
+      <name>ExternalUserUpgradePlugin</name>
+      <set-method>addUpgradePlugin</set-method>
+      <type>org.exoplatform.migration.UserSetExternalInGateinPortal</type>
+      <description>Add external information in gatein portal profile</description>
+      <init-params>
+        <value-param>
+          <name>product.group.id</name>
+          <description>The groupId of the product</description>
+          <value>org.exoplatform.platform</value>
+        </value-param>
+        <value-param>
+          <name>plugin.upgrade.target.version</name>
+          <description>The plugin target version (will not be executed if previous version is equal or higher than 6.3.1)
+          </description>
+          <value>6.3.x-maintenance-SNAPSHOT</value>
+        </value-param>
+        <value-param>
+          <name>plugin.execution.order</name>
+          <description>The plugin execution order</description>
+          <value>100</value>
+        </value-param>
+        <value-param>
+          <name>plugin.upgrade.execute.once</name>
+          <description>The plugin must be executed only once</description>
+          <value>true</value>
+        </value-param>
+        <value-param>
+          <name>plugin.upgrade.async.execution</name>
+          <description>The plugin will be executed in an asynchronous mode</description>
+          <value>true</value>
+        </value-param>
+      </init-params>
+    </component-plugin>
+  </external-component-plugins>
+
 </configuration>


### PR DESCRIPTION
Before this fix, the external status is tested in gatein profile, but is only present in social profile.
This commit update the listener which update the gatein profile when the social profile change to take care of this modification.
After that, as the external info is present in gatein profile, notification will be able to check it correctly.