### PR TITLE
Task-54884: External users receive notification of published news from a space of which they are not a member 

### DIFF
--- a/data-upgrade-users/pom.xml
+++ b/data-upgrade-users/pom.xml
@@ -1,0 +1,75 @@
+<!--
+
+    Copyright (C) 2022 eXo Platform SAS.
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+    You should have received a copy of the GNU Affero General Public License
+    along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.exoplatform.addons.upgrade</groupId>
+    <artifactId>upgrade</artifactId>
+    <version>6.2.x-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>data-upgrade-users</artifactId>
+  <packaging>jar</packaging>
+  <name>eXo Add-on:: Data Upgrade Add-on - users</name>
+  <description>A module to migrate lastLoginTime field on 6.1.x to 6.2.x </description>
+  <properties>
+    <exo.test.coverage.ratio>0.45</exo.test.coverage.ratio>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.exoplatform.commons</groupId>
+      <artifactId>commons-component-upgrade</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.exoplatform.commons</groupId>
+      <artifactId>commons-search</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+        <groupId>org.exoplatform.social</groupId>
+        <artifactId>social-component-core</artifactId>
+        <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+        <groupId>org.mockito</groupId>
+        <artifactId>mockito-core</artifactId>
+        <scope>test</scope>
+    </dependency>
+    <dependency>
+        <groupId>org.powermock</groupId>
+        <artifactId>powermock-api-mockito2</artifactId>
+        <scope>test</scope>
+    </dependency>
+    <dependency>
+        <groupId>org.powermock</groupId>
+        <artifactId>powermock-module-junit4</artifactId>
+        <scope>test</scope>
+    </dependency>
+      <dependency>
+          <groupId>org.exoplatform.social</groupId>
+          <artifactId>social-component-service</artifactId>
+          <scope>test</scope>
+      </dependency>
+  </dependencies>
+</project>

--- a/data-upgrade-users/src/main/java/org/exoplatform/migration/UserSetExternalInGateinPortal.java
+++ b/data-upgrade-users/src/main/java/org/exoplatform/migration/UserSetExternalInGateinPortal.java
@@ -1,4 +1,20 @@
-package org.exoplatform.migration;
+/*
+ * Copyright (C) 2022 eXo Platform SAS.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+ package org.exoplatform.migration;
 
 import org.exoplatform.commons.serialization.serial.ObjectReader;
 import org.exoplatform.commons.upgrade.UpgradeProductPlugin;

--- a/data-upgrade-users/src/main/java/org/exoplatform/migration/UserSetExternalInGateinPortal.java
+++ b/data-upgrade-users/src/main/java/org/exoplatform/migration/UserSetExternalInGateinPortal.java
@@ -16,7 +16,6 @@
  */
  package org.exoplatform.migration;
 
-import org.exoplatform.commons.serialization.serial.ObjectReader;
 import org.exoplatform.commons.upgrade.UpgradeProductPlugin;
 import org.exoplatform.commons.utils.ListAccess;
 import org.exoplatform.container.ExoContainerContext;
@@ -27,13 +26,12 @@ import org.exoplatform.services.log.Log;
 import org.exoplatform.services.organization.Group;
 import org.exoplatform.services.organization.Membership;
 import org.exoplatform.services.organization.OrganizationService;
-import org.exoplatform.services.organization.User;
 import org.exoplatform.services.organization.UserProfile;
 
 import java.util.Arrays;
 
 public class UserSetExternalInGateinPortal extends UpgradeProductPlugin {
-  private static final Log LOG = ExoLogger.getExoLogger(UsersLastLoginTimeMigration.class);
+  private static final Log LOG = ExoLogger.getExoLogger(UserSetExternalInGateinPortal.class);
 
   OrganizationService organizationService;
   public UserSetExternalInGateinPortal(OrganizationService organizationService,InitParams initParams) {

--- a/data-upgrade-users/src/main/java/org/exoplatform/migration/UserSetExternalInGateinPortal.java
+++ b/data-upgrade-users/src/main/java/org/exoplatform/migration/UserSetExternalInGateinPortal.java
@@ -1,0 +1,73 @@
+package org.exoplatform.migration;
+
+import org.exoplatform.commons.serialization.serial.ObjectReader;
+import org.exoplatform.commons.upgrade.UpgradeProductPlugin;
+import org.exoplatform.commons.utils.ListAccess;
+import org.exoplatform.container.ExoContainerContext;
+import org.exoplatform.container.component.RequestLifeCycle;
+import org.exoplatform.container.xml.InitParams;
+import org.exoplatform.services.log.ExoLogger;
+import org.exoplatform.services.log.Log;
+import org.exoplatform.services.organization.Group;
+import org.exoplatform.services.organization.Membership;
+import org.exoplatform.services.organization.OrganizationService;
+import org.exoplatform.services.organization.User;
+import org.exoplatform.services.organization.UserProfile;
+
+import java.util.Arrays;
+
+public class UserSetExternalInGateinPortal extends UpgradeProductPlugin {
+  private static final Log LOG = ExoLogger.getExoLogger(UsersLastLoginTimeMigration.class);
+
+  OrganizationService organizationService;
+  public UserSetExternalInGateinPortal(OrganizationService organizationService,InitParams initParams) {
+    super(initParams);
+    this.organizationService=organizationService;
+
+  }
+  @Override
+  public void processUpgrade(String oldVersion, String newVersion) {
+    LOG.info("Start upgrade process to add external info in gatein user profile");
+    long startupTime = System.currentTimeMillis();
+    try {
+      Group group = organizationService.getGroupHandler().findGroupById("/platform/externals");
+      ListAccess<Membership> externalsMemberships = organizationService.getMembershipHandler().findAllMembershipsByGroup(group);
+      int total = externalsMemberships.getSize();
+      LOG.info("Number of users to update : " + total);
+
+      int pageSize = 100;
+      int current=0;
+      while (current<total) {
+        RequestLifeCycle.begin(ExoContainerContext.getCurrentContainer());
+
+        Membership[] currentBatch = externalsMemberships.load(0,pageSize);
+        Arrays.stream(currentBatch).forEach(membership -> {
+          long startTimeForUser = System.currentTimeMillis();
+          String username = membership.getUserName();
+          try {
+            UserProfile profile = organizationService.getUserProfileHandler().findUserProfileByName(username);
+            if (profile==null) {
+              profile=organizationService.getUserProfileHandler().createUserProfileInstance(username);
+            }
+            profile.setAttribute(UserProfile.OTHER_KEYS[2],"true");
+            organizationService.getUserProfileHandler().saveUserProfile(profile,true);
+            LOG.debug("External info added in gatein profile for user {}, {}ms", username, System.currentTimeMillis() - startTimeForUser);
+          } catch (Exception e) {
+            LOG.error("Unable to get profile for user {}",username);
+          }
+        });
+        current=current+currentBatch.length;
+        LOG.info("Progession : {} users updated on {} total users. It tooks {}ms",
+                 current,
+                 total,
+                 System.currentTimeMillis() - startupTime);
+
+        RequestLifeCycle.end();
+
+
+      }
+    } catch (Exception e) {
+      LOG.error("Unable to find group externals");
+    }
+  }
+}

--- a/data-upgrade-users/src/main/resources/conf/portal/configuration.xml
+++ b/data-upgrade-users/src/main/resources/conf/portal/configuration.xml
@@ -22,44 +22,6 @@
   <external-component-plugins>
     <target-component>org.exoplatform.commons.upgrade.UpgradeProductService</target-component>
     <component-plugin>
-      <name>UserUpgradePlugin</name>
-      <set-method>addUpgradePlugin</set-method>
-      <type>org.exoplatform.migration.UsersLastLoginTimeMigration</type>
-      <description>Migrate lastLoginTime of users logs in 6.1 to  lastLoginTime in profile in 6.3</description>
-      <init-params>
-        <value-param>
-          <name>product.group.id</name>
-          <description>The groupId of the product</description>
-          <value>org.exoplatform.platform</value>
-        </value-param>
-        <value-param>
-          <name>plugin.upgrade.target.version</name>
-          <description>The plugin target version (will not be executed if previous version is equal or higher than 6.3.1)
-          </description>
-          <value>6.3.0</value>
-        </value-param>
-        <value-param>
-          <name>plugin.execution.order</name>
-          <description>The plugin execution order</description>
-          <value>100</value>
-        </value-param>
-        <value-param>
-          <name>plugin.upgrade.execute.once</name>
-          <description>The plugin must be executed only once</description>
-          <value>true</value>
-        </value-param>
-        <value-param>
-          <name>plugin.upgrade.async.execution</name>
-          <description>The plugin will be executed in an asynchronous mode</description>
-          <value>true</value>
-        </value-param>
-      </init-params>
-    </component-plugin>
-  </external-component-plugins>
-
-  <external-component-plugins>
-    <target-component>org.exoplatform.commons.upgrade.UpgradeProductService</target-component>
-    <component-plugin>
       <name>ExternalUserUpgradePlugin</name>
       <set-method>addUpgradePlugin</set-method>
       <type>org.exoplatform.migration.UserSetExternalInGateinPortal</type>
@@ -74,7 +36,7 @@
           <name>plugin.upgrade.target.version</name>
           <description>The plugin target version (will not be executed if previous version is equal or higher than 6.3.1)
           </description>
-          <value>6.3.x-maintenance-SNAPSHOT</value>
+          <value>6..2.6</value>
         </value-param>
         <value-param>
           <name>plugin.execution.order</name>

--- a/data-upgrade-users/src/main/resources/conf/portal/configuration.xml
+++ b/data-upgrade-users/src/main/resources/conf/portal/configuration.xml
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (C) 2003-2021 eXo Platform SAS.
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+-->
+<configuration xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.exoplatform.org/xml/ns/kernel_1_2.xsd http://www.exoplatform.org/xml/ns/kernel_1_2.xsd" xmlns="http://www.exoplatform.org/xml/ns/kernel_1_2.xsd">
+
+  <external-component-plugins>
+    <target-component>org.exoplatform.commons.upgrade.UpgradeProductService</target-component>
+    <component-plugin>
+      <name>UserUpgradePlugin</name>
+      <set-method>addUpgradePlugin</set-method>
+      <type>org.exoplatform.migration.UsersLastLoginTimeMigration</type>
+      <description>Migrate lastLoginTime of users logs in 6.1 to  lastLoginTime in profile in 6.3</description>
+      <init-params>
+        <value-param>
+          <name>product.group.id</name>
+          <description>The groupId of the product</description>
+          <value>org.exoplatform.platform</value>
+        </value-param>
+        <value-param>
+          <name>plugin.upgrade.target.version</name>
+          <description>The plugin target version (will not be executed if previous version is equal or higher than 6.3.1)
+          </description>
+          <value>6.3.0</value>
+        </value-param>
+        <value-param>
+          <name>plugin.execution.order</name>
+          <description>The plugin execution order</description>
+          <value>100</value>
+        </value-param>
+        <value-param>
+          <name>plugin.upgrade.execute.once</name>
+          <description>The plugin must be executed only once</description>
+          <value>true</value>
+        </value-param>
+        <value-param>
+          <name>plugin.upgrade.async.execution</name>
+          <description>The plugin will be executed in an asynchronous mode</description>
+          <value>true</value>
+        </value-param>
+      </init-params>
+    </component-plugin>
+  </external-component-plugins>
+
+  <external-component-plugins>
+    <target-component>org.exoplatform.commons.upgrade.UpgradeProductService</target-component>
+    <component-plugin>
+      <name>ExternalUserUpgradePlugin</name>
+      <set-method>addUpgradePlugin</set-method>
+      <type>org.exoplatform.migration.UserSetExternalInGateinPortal</type>
+      <description>Add external information in gatein portal profile</description>
+      <init-params>
+        <value-param>
+          <name>product.group.id</name>
+          <description>The groupId of the product</description>
+          <value>org.exoplatform.platform</value>
+        </value-param>
+        <value-param>
+          <name>plugin.upgrade.target.version</name>
+          <description>The plugin target version (will not be executed if previous version is equal or higher than 6.3.1)
+          </description>
+          <value>6.3.x-maintenance-SNAPSHOT</value>
+        </value-param>
+        <value-param>
+          <name>plugin.execution.order</name>
+          <description>The plugin execution order</description>
+          <value>100</value>
+        </value-param>
+        <value-param>
+          <name>plugin.upgrade.execute.once</name>
+          <description>The plugin must be executed only once</description>
+          <value>true</value>
+        </value-param>
+        <value-param>
+          <name>plugin.upgrade.async.execution</name>
+          <description>The plugin will be executed in an asynchronous mode</description>
+          <value>true</value>
+        </value-param>
+      </init-params>
+    </component-plugin>
+  </external-component-plugins>
+
+</configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -20,6 +20,7 @@
     <tag>HEAD</tag>
   </scm>
   <modules>
+    <module>data-upgrade-users</module>
     <module>data-upgrade-elasticsearch7</module>
     <module>data-upgrade-wiki</module>
     <module>data-upgrade-ecms</module>


### PR DESCRIPTION
Before this fix, the external status is tested in gatein profile, but is only present in social profile.
This commit update the listener which update the gatein profile when the social profile change to take care of this modification.
After that, as the external info is present in gatein profile, notification will be able to check it correctly.