### PR TITLE
Task-57126: Implement upgrade plugin to hide old published articles if archived or scheduled and display the others in news list portlets

### DIFF
--- a/data-upgrade-news/pom.xml
+++ b/data-upgrade-news/pom.xml
@@ -69,4 +69,12 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>com.jcabi</groupId>
+        <artifactId>jcabi-maven-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/data-upgrade-news/src/main/java/org/exoplatform/news/upgrade/targets/PublishedNewsDisplayedPropUpgrade.java
+++ b/data-upgrade-news/src/main/java/org/exoplatform/news/upgrade/targets/PublishedNewsDisplayedPropUpgrade.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright (C) 2022 eXo Platform SAS.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.exoplatform.news.upgrade.targets;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import javax.persistence.EntityManager;
+import javax.persistence.Query;
+
+import org.apache.commons.collections4.ListUtils;
+import org.apache.commons.lang3.StringUtils;
+
+import org.exoplatform.commons.api.persistence.ExoTransactional;
+import org.exoplatform.commons.persistence.impl.EntityManagerService;
+import org.exoplatform.commons.upgrade.UpgradeProductPlugin;
+import org.exoplatform.container.PortalContainer;
+import org.exoplatform.container.xml.InitParams;
+import org.exoplatform.news.model.News;
+import org.exoplatform.news.service.NewsService;
+import org.exoplatform.news.service.NewsTargetingService;
+import org.exoplatform.news.utils.NewsUtils;
+import org.exoplatform.services.log.ExoLogger;
+import org.exoplatform.services.log.Log;
+import org.exoplatform.social.core.jpa.storage.entity.MetadataItemEntity;
+import org.exoplatform.social.metadata.MetadataService;
+
+public class PublishedNewsDisplayedPropUpgrade extends UpgradeProductPlugin {
+
+  public static final String   STAGED_STATUS              = "staged";
+
+  private static final Log     LOG                        =
+                                   ExoLogger.getLogger(PublishedNewsDisplayedPropUpgrade.class.getName());
+
+  private EntityManagerService entityManagerService;
+
+  private NewsService          newsService;
+
+  private MetadataService      metadataService;
+
+  private PortalContainer      container;
+
+  private int                  migratedPublishedNewsCount = 0;                                            // Accessible
+                                                                                                          // by
+                                                                                                          // the
+                                                                                                          // test
+                                                                                                          // classes
+
+  public PublishedNewsDisplayedPropUpgrade(InitParams initParams,
+                                           EntityManagerService entityManagerService,
+                                           NewsService newsService,
+                                           MetadataService metadataService,
+                                           PortalContainer container) {
+    super(initParams);
+    this.entityManagerService = entityManagerService;
+    this.newsService = newsService;
+    this.metadataService = metadataService;
+    this.container = container;
+  }
+
+  public int getMigratedPublishedNewsCount() {
+    return migratedPublishedNewsCount;
+  }
+
+  @Override
+  public void processUpgrade(String oldVersion, String newVersion) {
+    long startupTime = System.currentTimeMillis();
+    LOG.info("Start published news migration");
+    List<MetadataItemEntity> newsTargetsMetadataItems = getNewsTargetMetadataItems();
+
+    int totalPublishedNewsCount = newsTargetsMetadataItems.size();
+    LOG.info("Total number of published news to be migrated: {}", totalPublishedNewsCount);
+    int notMigratedPublishedNewsCount = 0;
+    int processedPublishedNewsCount = 0;
+    for (List<MetadataItemEntity> newsTargetsMetadataItemsChunk : ListUtils.partition(newsTargetsMetadataItems, 10)) {
+      int notMigratedPublishedNewsCountByTransaction = manageNewsTargetsMetadataItemsProps(newsTargetsMetadataItemsChunk);
+      int processedPublishedNewsCountByTransaction = newsTargetsMetadataItemsChunk.size();
+      processedPublishedNewsCount += processedPublishedNewsCountByTransaction;
+      migratedPublishedNewsCount += processedPublishedNewsCountByTransaction - notMigratedPublishedNewsCountByTransaction;
+      notMigratedPublishedNewsCount += notMigratedPublishedNewsCountByTransaction;
+      LOG.info("Published news migration progress: processed={}/{} succeeded={} error={}",
+               processedPublishedNewsCount,
+               totalPublishedNewsCount,
+               migratedPublishedNewsCount,
+               notMigratedPublishedNewsCount);
+    }
+    if (notMigratedPublishedNewsCount == 0) {
+      LOG.info("End published news successful migration: total={} succeeded={} error={}. It tooks {} ms.",
+               totalPublishedNewsCount,
+               migratedPublishedNewsCount,
+               notMigratedPublishedNewsCount,
+               (System.currentTimeMillis() - startupTime));
+    } else {
+      LOG.warn("End published news migration with some errors: total={} succeeded={} error={}. It tooks {} ms."
+          + "The not migrated items will be processed again next startup.",
+               totalPublishedNewsCount,
+               migratedPublishedNewsCount,
+               notMigratedPublishedNewsCount,
+               (System.currentTimeMillis() - startupTime));
+      throw new IllegalStateException("Some news items wasn't executed successfully. It will be re-attempted next startup");
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  @ExoTransactional
+  public List<MetadataItemEntity> getNewsTargetMetadataItems() {
+    List<String> newsTargetMetadatas = metadataService.getMetadatas(NewsTargetingService.METADATA_TYPE.getName(), 0)
+                                                      .stream()
+                                                      .map(newsTargetMetadata -> String.valueOf(newsTargetMetadata.getId()))
+                                                      .collect(Collectors.toList());
+    EntityManager entityManager = entityManagerService.getEntityManager();
+    Query getNewsTargetMetadataItemsQuery =
+                                          entityManager.createNativeQuery("SELECT * FROM SOC_METADATA_ITEMS WHERE METADATA_ID IN :newsTargetMetadatas",
+                                                                          MetadataItemEntity.class);
+    getNewsTargetMetadataItemsQuery.setParameter("newsTargetMetadatas", newsTargetMetadatas);
+    return getNewsTargetMetadataItemsQuery.getResultList();
+  }
+
+  @ExoTransactional
+  public int manageNewsTargetsMetadataItemsProps(List<MetadataItemEntity> newsTargetsMetadataItems) {
+    int notMigratedPublishedNewsCount = 0;
+    for (MetadataItemEntity newsTargetsMetadataItem : newsTargetsMetadataItems) {
+      EntityManager entityManager = entityManagerService.getEntityManager();
+      try {
+        Query deleteNewsTargetMetadataItemsPropsQuery =
+                                                      entityManager.createNativeQuery("DELETE FROM SOC_METADATA_ITEMS_PROPERTIES WHERE METADATA_ITEM_ID = :newsTargetsMetadataItemId AND (NAME = :stagedStatus OR NAME = :displayedStatus)",
+                                                                                      MetadataItemEntity.class);
+        deleteNewsTargetMetadataItemsPropsQuery.setParameter("newsTargetsMetadataItemId", newsTargetsMetadataItem.getId());
+        deleteNewsTargetMetadataItemsPropsQuery.setParameter("stagedStatus", STAGED_STATUS);
+        deleteNewsTargetMetadataItemsPropsQuery.setParameter("displayedStatus", NewsUtils.DISPLAYED_STATUS);
+        deleteNewsTargetMetadataItemsPropsQuery.executeUpdate();
+
+        News news = newsService.getNewsById(newsTargetsMetadataItem.getObjectId(), false);
+        boolean displayed = !news.isArchived() && !StringUtils.equals(news.getPublicationState(), STAGED_STATUS);
+        Query insertNewsTargetMetadataItemsPropQuery =
+                                                     entityManager.createNativeQuery("INSERT INTO SOC_METADATA_ITEMS_PROPERTIES(METADATA_ITEM_ID, NAME, VALUE) VALUES(:newsTargetsMetadataItemId, :displayedStatus, :displayed)",
+                                                                                     MetadataItemEntity.class);
+        insertNewsTargetMetadataItemsPropQuery.setParameter("newsTargetsMetadataItemId", newsTargetsMetadataItem.getId());
+        insertNewsTargetMetadataItemsPropQuery.setParameter("displayedStatus", NewsUtils.DISPLAYED_STATUS);
+        insertNewsTargetMetadataItemsPropQuery.setParameter("displayed", String.valueOf(displayed));
+        insertNewsTargetMetadataItemsPropQuery.executeUpdate();
+      } catch (Exception e) {
+        LOG.warn("Error migrating metadata item with id {}. Continue to migrate other items", newsTargetsMetadataItem.getId(), e);
+        notMigratedPublishedNewsCount++;
+      }
+    }
+    return notMigratedPublishedNewsCount;
+  }
+}

--- a/data-upgrade-news/src/main/resources/conf/portal/configuration.xml
+++ b/data-upgrade-news/src/main/resources/conf/portal/configuration.xml
@@ -151,6 +151,39 @@
         </value-param>
       </init-params>
     </component-plugin>
+    <component-plugin profiles="news">
+      <name>PublishedNewsDisplayedPropUpgrade</name>
+      <set-method>addUpgradePlugin</set-method>
+      <type>org.exoplatform.news.upgrade.targets.PublishedNewsDisplayedPropUpgrade</type>
+      <description>Fix states metadata property</description>
+      <init-params>
+        <value-param>
+          <name>product.group.id</name>
+          <description>The groupId of the product</description>
+          <value>org.exoplatform.ecms</value>
+        </value-param>
+        <value-param>
+          <name>plugin.execution.order</name>
+          <description>The plugin execution order</description>
+          <value>2</value>
+        </value-param>
+        <value-param>
+          <name>plugin.upgrade.execute.once</name>
+          <description>Execute this upgrade plugin only once</description>
+          <value>true</value>
+        </value-param>
+        <value-param>
+          <name>plugin.upgrade.async.execution</name>
+          <description>The plugin will be executed in an asynchronous mode</description>
+          <value>true</value>
+        </value-param>
+        <value-param>
+          <name>plugin.upgrade.target.version</name>
+          <description>Target version of the plugin</description>
+          <value>6.3.0</value>
+        </value-param>
+      </init-params>
+    </component-plugin>
   </external-component-plugins>
 </configuration>
 

--- a/data-upgrade-news/src/test/java/org/exoplatform/news/upgrade/targets/PublishedNewsDisplayedPropUpgradeTest.java
+++ b/data-upgrade-news/src/test/java/org/exoplatform/news/upgrade/targets/PublishedNewsDisplayedPropUpgradeTest.java
@@ -1,0 +1,134 @@
+package org.exoplatform.news.upgrade.targets;
+
+import static org.jgroups.util.Util.assertEquals;
+import static org.powermock.api.mockito.PowerMockito.doNothing;
+import static org.powermock.api.mockito.PowerMockito.mock;
+import static org.powermock.api.mockito.PowerMockito.when;
+
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+
+import javax.persistence.EntityManager;
+import javax.persistence.Query;
+
+import org.hibernate.Transaction;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import org.exoplatform.commons.persistence.impl.EntityManagerService;
+import org.exoplatform.container.ExoContainerContext;
+import org.exoplatform.container.PortalContainer;
+import org.exoplatform.container.component.RequestLifeCycle;
+import org.exoplatform.container.xml.InitParams;
+import org.exoplatform.container.xml.ValueParam;
+import org.exoplatform.news.model.News;
+import org.exoplatform.news.service.NewsService;
+import org.exoplatform.social.core.jpa.storage.entity.MetadataEntity;
+import org.exoplatform.social.core.jpa.storage.entity.MetadataItemEntity;
+import org.exoplatform.social.metadata.MetadataService;
+import org.exoplatform.social.metadata.model.Metadata;
+import org.exoplatform.social.metadata.model.MetadataType;
+
+@RunWith(PowerMockRunner.class)
+@PowerMockIgnore({ "javax.management.*", "jdk.internal.*", "javax.xml.*", "org.apache.xerces.*", "org.xml.*",
+    "com.sun.org.apache.*", "org.w3c.*" })
+@PrepareForTest({ExoContainerContext.class, PortalContainer.class, RequestLifeCycle.class})
+public class PublishedNewsDisplayedPropUpgradeTest {
+
+  @Mock
+  private EntityManagerService entityManagerService;
+  
+  @Mock
+  private NewsService          newsService;
+
+  @Mock
+  private MetadataService      metadataService;
+
+  @Mock
+  private EntityManager entityManager;
+
+  @Before
+  public void setUp() throws Exception {
+    PowerMockito.mockStatic(ExoContainerContext.class);
+    PowerMockito.mockStatic(PortalContainer.class);
+    PowerMockito.mockStatic(RequestLifeCycle.class);
+  }
+
+  @Test
+  public void processUpgrade() throws Exception {
+    InitParams initParams = new InitParams();
+    ValueParam valueParam = new ValueParam();
+    valueParam.setName("product.group.id");
+    valueParam.setValue("org.exoplatform.platform");
+    initParams.addParameter(valueParam);
+    MetadataType metadataType = new MetadataType(4, "newsTarget");
+    List<Metadata> newsTargets = new LinkedList<>();
+    Metadata sliderNews = new Metadata();
+    sliderNews.setName("sliderNews");
+    sliderNews.setCreatedDate(100);
+    HashMap<String, String> sliderNewsProperties = new HashMap<>();
+    sliderNewsProperties.put("label", "slider news");
+    sliderNews.setProperties(sliderNewsProperties);
+    sliderNews.setId(1);
+    newsTargets.add(sliderNews);
+    MetadataEntity metadataEntity = new MetadataEntity();
+    metadataEntity.setCreatorId(1);
+    metadataEntity.setId(1l);
+    metadataEntity.setProperties(sliderNewsProperties);
+    metadataEntity.setAudienceId(0);
+    MetadataItemEntity metadataItemEntity = new MetadataItemEntity();
+    metadataItemEntity.setCreatorId(1);
+    metadataItemEntity.setId(1l);
+    metadataItemEntity.setObjectId("1");
+    metadataItemEntity.setMetadata(metadataEntity);
+    List<MetadataItemEntity> metadataItemEntities = new LinkedList<>();
+    metadataItemEntities.add(metadataItemEntity);
+    News news = new News();
+    news.setId("1");
+    news.setArchived(false);
+    news.setPublicationState("published");
+    
+    Transaction transaction = mock(Transaction.class);
+    PortalContainer container = mock(PortalContainer.class);
+    
+    Query nativeQuery1 = mock(Query.class);
+    Query nativeQuery2 = mock(Query.class);
+    Query nativeQuery3 = mock(Query.class);
+    
+    when(ExoContainerContext.getCurrentContainer()).thenReturn(container);
+    when(container.getComponentInstanceOfType(EntityManagerService.class)).thenReturn(entityManagerService);
+    when(entityManagerService.getEntityManager()).thenReturn(entityManager);
+    when(entityManager.getTransaction()).thenReturn(transaction);
+    when(transaction.isActive()).thenReturn(true);
+    doNothing().when(transaction).begin();
+    
+    when(metadataService.getMetadatas(metadataType.getName(), 0)).thenReturn(newsTargets);
+    when(newsService.getNewsById("1", false)).thenReturn(news);
+
+    when(entityManager.createNativeQuery(Mockito.anyString(), Mockito.eq(MetadataItemEntity.class))).thenReturn(nativeQuery1);
+    when(nativeQuery1.getResultList()).thenReturn(metadataItemEntities);
+
+    when(entityManager.createNativeQuery(Mockito.anyString(), Mockito.eq(MetadataItemEntity.class))).thenReturn(nativeQuery2);
+    when(nativeQuery2.executeUpdate()).thenReturn(1);
+    
+    when(entityManager.createNativeQuery(Mockito.anyString(), Mockito.eq(MetadataItemEntity.class))).thenReturn(nativeQuery3);
+    when(nativeQuery3.executeUpdate()).thenReturn(1);
+    
+    PublishedNewsDisplayedPropUpgrade publishedNewsDisplayedPropUpgradePlugin = new PublishedNewsDisplayedPropUpgrade(initParams,
+                                                                                                                      entityManagerService,
+                                                                                                                      newsService,
+                                                                                                                      metadataService,
+                                                                                                                      container);
+
+    publishedNewsDisplayedPropUpgradePlugin.processUpgrade(null, null);
+    assertEquals(1, publishedNewsDisplayedPropUpgradePlugin.getMigratedPublishedNewsCount());
+  }
+}


### PR DESCRIPTION

This upgrade plugin is implemented in order to add a displayed status as a metadataItemProperty related to the metatdataItem combining the published news and its target. This will allow to hide the old published articles if archived or scheduled from news list portlets by adding false "displayed" metadataItemProperties and make other old published articles visible in news list portlets by adding true their "displayed" metadataItemProperties . This upgrade plugin will allow also to clean all old "staged" metadataItemProperties.