### PR TITLE
Task-57126: Fix explicit type casting problem caused by select SOC_METADATA_ITEMS query with postgreSQL

### DIFF
--- a/data-upgrade-news/src/main/java/org/exoplatform/news/upgrade/targets/PublishedNewsDisplayedPropUpgrade.java
+++ b/data-upgrade-news/src/main/java/org/exoplatform/news/upgrade/targets/PublishedNewsDisplayedPropUpgrade.java
@@ -28,7 +28,6 @@ import org.apache.commons.lang3.StringUtils;
 import org.exoplatform.commons.api.persistence.ExoTransactional;
 import org.exoplatform.commons.persistence.impl.EntityManagerService;
 import org.exoplatform.commons.upgrade.UpgradeProductPlugin;
-import org.exoplatform.container.PortalContainer;
 import org.exoplatform.container.xml.InitParams;
 import org.exoplatform.news.model.News;
 import org.exoplatform.news.service.NewsService;
@@ -38,6 +37,7 @@ import org.exoplatform.services.log.ExoLogger;
 import org.exoplatform.services.log.Log;
 import org.exoplatform.social.core.jpa.storage.entity.MetadataItemEntity;
 import org.exoplatform.social.metadata.MetadataService;
+import org.exoplatform.social.metadata.model.Metadata;
 
 public class PublishedNewsDisplayedPropUpgrade extends UpgradeProductPlugin {
 
@@ -52,8 +52,6 @@ public class PublishedNewsDisplayedPropUpgrade extends UpgradeProductPlugin {
 
   private MetadataService      metadataService;
 
-  private PortalContainer      container;
-
   private int                  migratedPublishedNewsCount = 0;                                            // Accessible
                                                                                                           // by
                                                                                                           // the
@@ -63,13 +61,11 @@ public class PublishedNewsDisplayedPropUpgrade extends UpgradeProductPlugin {
   public PublishedNewsDisplayedPropUpgrade(InitParams initParams,
                                            EntityManagerService entityManagerService,
                                            NewsService newsService,
-                                           MetadataService metadataService,
-                                           PortalContainer container) {
+                                           MetadataService metadataService) {
     super(initParams);
     this.entityManagerService = entityManagerService;
     this.newsService = newsService;
     this.metadataService = metadataService;
-    this.container = container;
   }
 
   public int getMigratedPublishedNewsCount() {
@@ -118,9 +114,9 @@ public class PublishedNewsDisplayedPropUpgrade extends UpgradeProductPlugin {
   @SuppressWarnings("unchecked")
   @ExoTransactional
   public List<MetadataItemEntity> getNewsTargetMetadataItems() {
-    List<String> newsTargetMetadatas = metadataService.getMetadatas(NewsTargetingService.METADATA_TYPE.getName(), 0)
+    List<Long> newsTargetMetadatas = metadataService.getMetadatas(NewsTargetingService.METADATA_TYPE.getName(), 0)
                                                       .stream()
-                                                      .map(newsTargetMetadata -> String.valueOf(newsTargetMetadata.getId()))
+                                                      .map(Metadata::getId)
                                                       .collect(Collectors.toList());
     EntityManager entityManager = entityManagerService.getEntityManager();
     Query getNewsTargetMetadataItemsQuery =

--- a/data-upgrade-news/src/test/java/org/exoplatform/news/upgrade/targets/PublishedNewsDisplayedPropUpgradeTest.java
+++ b/data-upgrade-news/src/test/java/org/exoplatform/news/upgrade/targets/PublishedNewsDisplayedPropUpgradeTest.java
@@ -125,8 +125,7 @@ public class PublishedNewsDisplayedPropUpgradeTest {
     PublishedNewsDisplayedPropUpgrade publishedNewsDisplayedPropUpgradePlugin = new PublishedNewsDisplayedPropUpgrade(initParams,
                                                                                                                       entityManagerService,
                                                                                                                       newsService,
-                                                                                                                      metadataService,
-                                                                                                                      container);
+                                                                                                                      metadataService);
 
     publishedNewsDisplayedPropUpgradePlugin.processUpgrade(null, null);
     assertEquals(1, publishedNewsDisplayedPropUpgradePlugin.getMigratedPublishedNewsCount());


### PR DESCRIPTION
Prior to this change, an exception:

> org.hibernate.exception.SQLGrammarException: could not extract ResultSet 
  Caused by: org.postgresql.util.PSQLException: ERROR: operator does not exist: bigint = character varying
  Hint: No operator matches the given name and argument types. You might need to add explicit type casts.

occurs when the PublishedNewsDisplayedPropUpgrade is executed in postgreSQL instances which causes an explicit type casting problem between METADATA_ID field and values used by the where condition of the select SOC_METADATA_ITEMS_PROPERTIES query. After this fix, we ensure the implicit casting between METADATA_ID field type and the values used in the where condition.

