### PR TITLE
fix: Upgrade plugin are not working with postgres - EXO-59964

### DIFF
--- a/data-upgrade-app-registry/src/main/java/org/exoplatform/application/upgrade/AppRegistryUpgradePlugin.java
+++ b/data-upgrade-app-registry/src/main/java/org/exoplatform/application/upgrade/AppRegistryUpgradePlugin.java
@@ -101,7 +101,7 @@ public class AppRegistryUpgradePlugin extends UpgradeProductPlugin {
           transactionStarted = true;
         }
 
-        String sqlString = "UPDATE PORTAL_APPLICATIONS w SET w.DISPLAY_NAME = '"+newDisplayName+"' , w.DESCRIPTION = '"+newDescription+"' , w.APP_NAME = '"+newAppName+"', w.CONTENT_ID = '"+newContentId+"' WHERE w.CONTENT_ID = '"+oldContentId+"'  AND w.ID > 0;";
+        String sqlString = "UPDATE PORTAL_APPLICATIONS SET DISPLAY_NAME = '"+newDisplayName+"' , DESCRIPTION = '"+newDescription+"' , APP_NAME = '"+newAppName+"', CONTENT_ID = '"+newContentId+"' WHERE CONTENT_ID = '"+oldContentId+"'  AND ID > 0;";
         Query nativeQuery = entityManager.createNativeQuery(sqlString);
         this.pagesUpdatedCount = nativeQuery.executeUpdate();
         LOG.info("End upgrade of '{}' apps with content id {} in registry to use {}. It took {} ms",

--- a/data-upgrade-navigations/src/main/java/org/exoplatform/migration/NavigationNotesMigration.java
+++ b/data-upgrade-navigations/src/main/java/org/exoplatform/migration/NavigationNotesMigration.java
@@ -95,9 +95,9 @@ public class NavigationNotesMigration extends UpgradeProductPlugin {
           transactionStarted = true;
         }
 
-        String sqlString = "UPDATE PORTAL_NAVIGATION_NODES w SET w.NAME = '" + newNavName
-            + "' , w.LABEL = '" + newNavLabel
-            + "' WHERE w.NAME = '" + oldNavName + "' AND w.NODE_ID > 0;";
+        String sqlString = "UPDATE PORTAL_NAVIGATION_NODES SET NAME = '" + newNavName
+            + "' ,LABEL = '" + newNavLabel
+            + "' WHERE NAME = '" + oldNavName + "' AND NODE_ID > 0;";
         Query nativeQuery = entityManager.createNativeQuery(sqlString);
         this.pagesNodesCount = nativeQuery.executeUpdate();
 

--- a/data-upgrade-pages/src/main/java/org/exoplatform/migration/PopularSpacesRemovePreferences.java
+++ b/data-upgrade-pages/src/main/java/org/exoplatform/migration/PopularSpacesRemovePreferences.java
@@ -56,7 +56,7 @@ public class PopularSpacesRemovePreferences extends UpgradeProductPlugin {
                 entityManager.getTransaction().begin();
                 transactionStarted = true;
             }
-            String sqlString = "UPDATE PORTAL_WINDOWS w SET w.CUSTOMIZATION = NULL WHERE w.CONTENT_ID = '" + APPLICATION_CONTENT_ID + "'";
+            String sqlString = "UPDATE PORTAL_WINDOWS SET CUSTOMIZATION = NULL WHERE CONTENT_ID = '" + APPLICATION_CONTENT_ID + "'";
             Query nativeQuery = entityManager.createNativeQuery(sqlString);
             int update = nativeQuery.executeUpdate();
             if (update != 0) {

--- a/data-upgrade-wiki/src/main/java/org/exoplatform/wiki/upgrade/WikiPageNameUpgradePlugin.java
+++ b/data-upgrade-wiki/src/main/java/org/exoplatform/wiki/upgrade/WikiPageNameUpgradePlugin.java
@@ -83,8 +83,8 @@ public class WikiPageNameUpgradePlugin extends UpgradeProductPlugin {
           transactionStarted = true;
         }
 
-        String sqlString = "UPDATE WIKI_PAGES w SET w.NAME = '" + newNoteName
-                + "' , w.TITLE = '"+ newTitle +"' WHERE w.NAME = '" + oldNoteName + "' AND w.PAGE_ID > 0;";
+        String sqlString = "UPDATE WIKI_PAGES SET NAME = '" + newNoteName
+                + "' , TITLE = '"+ newTitle +"' WHERE NAME = '" + oldNoteName + "' AND PAGE_ID > 0;";
         Query nativeQuery = entityManager.createNativeQuery(sqlString);
         this.pagesUpdatedCount = nativeQuery.executeUpdate();
         LOG.info("End upgrade of '{}' notes with name '{}' to use name '{}'. It took {} ms",


### PR DESCRIPTION
Before this fix, four upgrade plugins are not working with psql due to usage of alias for table name in update query This fix removes alias usage.