### PR TITLE
feat: Set /platform/web-contributors permission to old targets without permissions - EXO-61243

### DIFF
--- a/data-upgrade-news/src/main/java/org/exoplatform/news/upgrade/targets/TargetsDefaultPermissionUpgrade.java
+++ b/data-upgrade-news/src/main/java/org/exoplatform/news/upgrade/targets/TargetsDefaultPermissionUpgrade.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright (C) 2022 eXo Platform SAS.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.exoplatform.news.upgrade.targets;
+
+import java.util.List;
+import java.util.Map;
+
+import org.apache.commons.collections4.ListUtils;
+
+import org.exoplatform.commons.upgrade.UpgradeProductPlugin;
+import org.exoplatform.container.xml.InitParams;
+import org.exoplatform.news.service.NewsTargetingService;
+import org.exoplatform.news.utils.NewsUtils;
+import org.exoplatform.services.log.ExoLogger;
+import org.exoplatform.services.log.Log;
+import org.exoplatform.social.core.metadata.storage.MetadataStorage;
+import org.exoplatform.social.metadata.MetadataService;
+import org.exoplatform.social.metadata.model.Metadata;
+
+public class TargetsDefaultPermissionUpgrade extends UpgradeProductPlugin {
+
+  private static final Log LOG                                     =
+                               ExoLogger.getLogger(TargetsDefaultPermissionUpgrade.class.getName());
+
+  private MetadataService  metadataService;
+
+  private MetadataStorage  metadataStorage;
+
+  private int              migratedNoDefaultPermissionTargetsCount = 0;
+
+  public TargetsDefaultPermissionUpgrade(InitParams initParams,
+                                         MetadataService metadataService,
+                                         MetadataStorage metadataStorage) {
+    super(initParams);
+    this.metadataService = metadataService;
+    this.metadataStorage = metadataStorage;
+  }
+
+  public int getMigratedNoDefaultPermissionTargetsCount() {
+    return migratedNoDefaultPermissionTargetsCount;
+  }
+
+  @Override
+  public void processUpgrade(String oldVersion, String newVersion) {
+    long startupTime = System.currentTimeMillis();
+    LOG.info("Start targets migration");
+    List<Metadata> noDefaultPermissionTargets = metadataService.getMetadatas(NewsTargetingService.METADATA_TYPE.getName(), 0)
+                                                               .stream()
+                                                               .filter(target -> target.getProperties()
+                                                                                       .get(NewsUtils.TARGET_PERMISSIONS) == null)
+                                                               .toList();
+
+    int totalNoDefaultPermissionTargetsCount = noDefaultPermissionTargets.size();
+    LOG.info("Total number of no default permission targets to be migrated: {}", totalNoDefaultPermissionTargetsCount);
+    int notMigratedNoDefaultPermissionTargetsCount = 0;
+    int processedNoDefaultPermissionTargetsCount = 0;
+    for (List<Metadata> noDefaultPermissionTargetsChunk : ListUtils.partition(noDefaultPermissionTargets, 10)) {
+      int notMigratedNoDefaultPermissionTargetsCountByTransaction =
+                                                                  manageNoDefaultPermissionTargets(noDefaultPermissionTargetsChunk);
+      int processedNoDefaultPermissionTargetsCountByTransaction = noDefaultPermissionTargetsChunk.size();
+      processedNoDefaultPermissionTargetsCount += processedNoDefaultPermissionTargetsCountByTransaction;
+      migratedNoDefaultPermissionTargetsCount += processedNoDefaultPermissionTargetsCountByTransaction
+          - notMigratedNoDefaultPermissionTargetsCountByTransaction;
+      notMigratedNoDefaultPermissionTargetsCount += notMigratedNoDefaultPermissionTargetsCountByTransaction;
+      LOG.info("No default permission targets migration progress: processed={}/{} succeeded={} error={}",
+               processedNoDefaultPermissionTargetsCount,
+               totalNoDefaultPermissionTargetsCount,
+               migratedNoDefaultPermissionTargetsCount,
+               notMigratedNoDefaultPermissionTargetsCount);
+    }
+    if (notMigratedNoDefaultPermissionTargetsCount == 0) {
+      LOG.info("End no default permission targets successful migration: total={} succeeded={} error={}. It tooks {} ms.",
+               totalNoDefaultPermissionTargetsCount,
+               migratedNoDefaultPermissionTargetsCount,
+               notMigratedNoDefaultPermissionTargetsCount,
+               (System.currentTimeMillis() - startupTime));
+    } else {
+      LOG.warn("End no default permission targets migration with some errors: total={} succeeded={} error={}. It tooks {} ms."
+          + "The not migrated no default permission targets will be processed again next startup.",
+               totalNoDefaultPermissionTargetsCount,
+               migratedNoDefaultPermissionTargetsCount,
+               notMigratedNoDefaultPermissionTargetsCount,
+               (System.currentTimeMillis() - startupTime));
+      throw new IllegalStateException("Some no default permission targets wasn't executed successfully. It will be re-attempted next startup");
+    }
+  }
+
+  public int manageNoDefaultPermissionTargets(List<Metadata> noDefaultPermissionTargets) {
+    int notMigratedNoDefaultPermissionTargetsCount = 0;
+    for (Metadata noDefaultPermissionTarget : noDefaultPermissionTargets) {
+      try {
+        Map<String, String> noDefaultPermissionTargetProperties = noDefaultPermissionTarget.getProperties();
+        noDefaultPermissionTargetProperties.put(NewsUtils.TARGET_PERMISSIONS, "/platform/web-contributors");
+        noDefaultPermissionTarget.setProperties(noDefaultPermissionTargetProperties);
+        metadataStorage.updateMetadata(noDefaultPermissionTarget);
+      } catch (Exception e) {
+        LOG.warn("Error migrating no default permission targets with id {}. Continue to migrate other items",
+                 noDefaultPermissionTarget.getId(),
+                 e);
+        notMigratedNoDefaultPermissionTargetsCount++;
+      }
+    }
+    return notMigratedNoDefaultPermissionTargetsCount;
+  }
+}

--- a/data-upgrade-news/src/main/resources/conf/portal/configuration.xml
+++ b/data-upgrade-news/src/main/resources/conf/portal/configuration.xml
@@ -184,6 +184,38 @@
         </value-param>
       </init-params>
     </component-plugin>
+    <component-plugin profiles="news">
+      <name>TargetsDefaultPermissionUpgrade</name>
+      <set-method>addUpgradePlugin</set-method>
+      <type>org.exoplatform.news.upgrade.targets.TargetsDefaultPermissionUpgrade</type>
+      <description>Set default permission for old targets</description>
+      <init-params>
+        <value-param>
+          <name>product.group.id</name>
+          <description>The groupId of the product</description>
+          <value>org.exoplatform.ecms</value>
+        </value-param>
+        <value-param>
+          <name>plugin.execution.order</name>
+          <description>The plugin execution order</description>
+          <value>2</value>
+        </value-param>
+        <value-param>
+          <name>plugin.upgrade.execute.once</name>
+          <description>Execute this upgrade plugin only once</description>
+          <value>true</value>
+        </value-param>
+        <value-param>
+          <name>plugin.upgrade.async.execution</name>
+          <description>The plugin will be executed in an asynchronous mode</description>
+          <value>true</value>
+        </value-param>
+        <value-param>
+          <name>plugin.upgrade.target.version</name>
+          <description>Target version of the plugin</description>
+          <value>6.4.0</value>
+        </value-param>
+      </init-params>
+    </component-plugin>
   </external-component-plugins>
 </configuration>
-

--- a/data-upgrade-news/src/test/java/org/exoplatform/news/upgrade/targets/TargetsDefaultPermissionUpgradeTest.java
+++ b/data-upgrade-news/src/test/java/org/exoplatform/news/upgrade/targets/TargetsDefaultPermissionUpgradeTest.java
@@ -1,0 +1,92 @@
+package org.exoplatform.news.upgrade.targets;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.powermock.api.mockito.PowerMockito.when;
+
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import org.exoplatform.container.ExoContainerContext;
+import org.exoplatform.container.PortalContainer;
+import org.exoplatform.container.component.RequestLifeCycle;
+import org.exoplatform.container.xml.InitParams;
+import org.exoplatform.container.xml.ValueParam;
+import org.exoplatform.news.utils.NewsUtils;
+import org.exoplatform.social.core.metadata.storage.MetadataStorage;
+import org.exoplatform.social.metadata.MetadataService;
+import org.exoplatform.social.metadata.model.Metadata;
+import org.exoplatform.social.metadata.model.MetadataType;
+
+@RunWith(PowerMockRunner.class)
+@PowerMockIgnore({ "javax.management.*", "jdk.internal.*", "javax.xml.*", "org.apache.xerces.*", "org.xml.*",
+    "com.sun.org.apache.*", "org.w3c.*" })
+@PrepareForTest({ ExoContainerContext.class, PortalContainer.class, RequestLifeCycle.class })
+public class TargetsDefaultPermissionUpgradeTest {
+
+  @Mock
+  private MetadataService metadataService;
+
+  @Mock
+  private MetadataStorage metadataStorage;
+
+  @Test
+  public void processUpgrade() throws Exception {
+    InitParams initParams = new InitParams();
+    ValueParam valueParam = new ValueParam();
+    valueParam.setName("product.group.id");
+    valueParam.setValue("org.exoplatform.platform");
+    initParams.addParameter(valueParam);
+    MetadataType metadataType = new MetadataType(4, "newsTarget");
+    List<Metadata> newsTargets = new LinkedList<>();
+    Metadata sliderNews = new Metadata();
+    sliderNews.setName("sliderNews");
+    sliderNews.setCreatedDate(100);
+    HashMap<String, String> sliderNewsProperties = new HashMap<>();
+    sliderNewsProperties.put("label", "slider news");
+    sliderNews.setProperties(sliderNewsProperties);
+    sliderNews.setId(1);
+    newsTargets.add(sliderNews);
+    
+    Metadata latestNews = new Metadata();
+    latestNews.setName("latestNews");
+    latestNews.setCreatedDate(100);
+    HashMap<String, String> latestNewsProperties = new HashMap<>();
+    latestNewsProperties.put("label", "latest news");
+    latestNewsProperties.put(NewsUtils.TARGET_PERMISSIONS, "space:1");
+    latestNews.setProperties(latestNewsProperties);
+    latestNews.setId(2);
+    newsTargets.add(latestNews);
+    
+    Metadata testNews = new Metadata();
+    testNews.setName("testNews");
+    testNews.setCreatedDate(100);
+    HashMap<String, String> testNewsProperties = new HashMap<>();
+    testNewsProperties.put("label", "test news");
+    testNews.setProperties(testNewsProperties);
+    testNews.setId(3);
+    newsTargets.add(testNews);
+
+    when(metadataService.getMetadatas(metadataType.getName(), 0)).thenReturn(newsTargets);
+
+    TargetsDefaultPermissionUpgrade targetsDefaultPermissionUpgrade = new TargetsDefaultPermissionUpgrade(initParams,
+                                                                                                          metadataService,
+                                                                                                          metadataStorage);
+
+    targetsDefaultPermissionUpgrade.processUpgrade(null, null);
+    verify(metadataStorage, times(2)).updateMetadata(any());
+    assertEquals(2, targetsDefaultPermissionUpgrade.getMigratedNoDefaultPermissionTargetsCount());
+  }
+}


### PR DESCRIPTION

Prior to this change, old news targets are created without permissions. We need to upgrade them by setting them default /platform/web-contributors permission which will be considered for allowed targets displayed in different drawers and news list portlets settings.