### PR TITLE
feat: Add UpgradePlugin to reload a PortalConfiguration - EXO-61993

### DIFF
--- a/data-upgrade-pages/pom.xml
+++ b/data-upgrade-pages/pom.xml
@@ -32,7 +32,7 @@
   <name>eXo Add-on:: Data Upgrade Add-on - Pages</name>
   <description>A module to migrate old pages to use new applications</description>
   <properties>
-    <exo.test.coverage.ratio>0.72</exo.test.coverage.ratio>
+    <exo.test.coverage.ratio>0.85</exo.test.coverage.ratio>
   </properties>
 
   <dependencies>

--- a/data-upgrade-pages/src/main/java/org/exoplatform/migration/ReloadPortalConfigurationMigration.java
+++ b/data-upgrade-pages/src/main/java/org/exoplatform/migration/ReloadPortalConfigurationMigration.java
@@ -11,11 +11,11 @@ public class ReloadPortalConfigurationMigration extends UpgradeProductPlugin {
 
   private UserPortalConfigService userPortalConfigService;
 
-  String OWNER_TYPE = "ownerType";
-  String PREDEFINED_OWNER = "predefinedOwner";
-  String LOCATION = "location";
-  String IMPORT_MODE = "importMode";
-  String OVERRIDE_MODE = "overrideMode";
+  private static final String OWNER_TYPE = "ownerType";
+  private static final String PREDEFINED_OWNER   = "predefinedOwner";
+  private static final String LOCATION_PARAMETER = "location";
+  private static final String IMPORT_MODE        = "importMode";
+  private static final String OVERRIDE_MODE = "overrideMode";
 
   String ownerType;
   String predefinedOwner;
@@ -31,8 +31,8 @@ public class ReloadPortalConfigurationMigration extends UpgradeProductPlugin {
     if (initParams.containsKey(PREDEFINED_OWNER) && !initParams.getValueParam(PREDEFINED_OWNER).getValue().isBlank()) {
       predefinedOwner=initParams.getValueParam(PREDEFINED_OWNER).getValue();
     }
-    if (initParams.containsKey(LOCATION) && !initParams.getValueParam(LOCATION).getValue().isBlank()) {
-      location=initParams.getValueParam(LOCATION).getValue();
+    if (initParams.containsKey(LOCATION_PARAMETER) && !initParams.getValueParam(LOCATION_PARAMETER).getValue().isBlank()) {
+      location=initParams.getValueParam(LOCATION_PARAMETER).getValue();
     }
     if (initParams.containsKey(IMPORT_MODE) && !initParams.getValueParam(IMPORT_MODE).getValue().isBlank()) {
       importMode=initParams.getValueParam(IMPORT_MODE).getValue();

--- a/data-upgrade-pages/src/main/java/org/exoplatform/migration/ReloadPortalConfigurationMigration.java
+++ b/data-upgrade-pages/src/main/java/org/exoplatform/migration/ReloadPortalConfigurationMigration.java
@@ -1,0 +1,58 @@
+package org.exoplatform.migration;
+
+import org.exoplatform.commons.upgrade.UpgradeProductPlugin;
+import org.exoplatform.container.xml.InitParams;
+import org.exoplatform.portal.config.UserPortalConfigService;
+import org.exoplatform.services.log.ExoLogger;
+import org.exoplatform.services.log.Log;
+
+public class ReloadPortalConfigurationMigration extends UpgradeProductPlugin {
+  private static final Log LOG = ExoLogger.getExoLogger(ReloadPortalConfigurationMigration.class);
+
+  private UserPortalConfigService userPortalConfigService;
+
+  String OWNER_TYPE = "ownerType";
+  String PREDEFINED_OWNER = "predefinedOwner";
+  String LOCATION = "location";
+  String IMPORT_MODE = "importMode";
+  String OVERRIDE_MODE = "overrideMode";
+
+  String ownerType;
+  String predefinedOwner;
+  String location;
+  String importMode;
+  boolean overrideMode = false;
+  public ReloadPortalConfigurationMigration(UserPortalConfigService userPortalConfigService, InitParams initParams) {
+    super(initParams);
+
+    if (initParams.containsKey(OWNER_TYPE) && !initParams.getValueParam(OWNER_TYPE).getValue().isBlank()) {
+      ownerType=initParams.getValueParam(OWNER_TYPE).getValue();
+    }
+    if (initParams.containsKey(PREDEFINED_OWNER) && !initParams.getValueParam(PREDEFINED_OWNER).getValue().isBlank()) {
+      predefinedOwner=initParams.getValueParam(PREDEFINED_OWNER).getValue();
+    }
+    if (initParams.containsKey(LOCATION) && !initParams.getValueParam(LOCATION).getValue().isBlank()) {
+      location=initParams.getValueParam(LOCATION).getValue();
+    }
+    if (initParams.containsKey(IMPORT_MODE) && !initParams.getValueParam(IMPORT_MODE).getValue().isBlank()) {
+      importMode=initParams.getValueParam(IMPORT_MODE).getValue();
+    }
+    if (initParams.containsKey(OVERRIDE_MODE) && !initParams.getValueParam(OVERRIDE_MODE).getValue().isBlank()) {
+      overrideMode=Boolean.parseBoolean(initParams.getValueParam(OVERRIDE_MODE).getValue());
+    }
+    this.userPortalConfigService = userPortalConfigService;
+  }
+
+  @Override
+  public void processUpgrade(String s, String s1) {
+    LOG.info("Start Upgrade ReloadPortalConfigurationMigration");
+    if (ownerType!=null && predefinedOwner!=null && location!=null && importMode!=null) {
+      userPortalConfigService.reloadConfig(ownerType,predefinedOwner,location,importMode,overrideMode);
+    } else {
+      LOG.error("At least one parameter is null : ownerType={}, predefinedOwner={}, location={}, importMode={}, overrideMode={}", ownerType,predefinedOwner,location,importMode,overrideMode);
+      throw new RuntimeException("An error occurred while applying Upgrade Plugin ReloadPortalConfigurationMigration. Check plugin configuration");
+    }
+    LOG.info("End Upgrade ReloadPortalConfigurationMigration");
+
+  }
+}

--- a/data-upgrade-pages/src/main/resources/conf/portal/configuration.xml
+++ b/data-upgrade-pages/src/main/resources/conf/portal/configuration.xml
@@ -473,4 +473,66 @@
       </init-params>
     </component-plugin>
   </external-component-plugins>
+
+  <external-component-plugins>
+    <target-component>org.exoplatform.commons.upgrade.UpgradeProductService</target-component>
+    <component-plugin>
+      <name>ReloadPortalConfigurationMigration</name>
+      <set-method>addUpgradePlugin</set-method>
+      <type>org.exoplatform.migration.ReloadPortalConfigurationMigration</type>
+      <description>Reload the portal configuration</description>
+      <init-params>
+        <value-param>
+          <name>product.group.id</name>
+          <description>The groupId of the product</description>
+          <value>org.exoplatform.platform</value>
+        </value-param>
+        <value-param>
+          <name>plugin.upgrade.target.version</name>
+          <description>The plugin target version of selected groupId</description>
+          <value>6.4.0</value>
+        </value-param>
+        <value-param>
+          <name>plugin.execution.order</name>
+          <description>The plugin execution order</description>
+          <value>10</value>
+        </value-param>
+        <value-param>
+          <name>plugin.upgrade.execute.once</name>
+          <description>The plugin must be executed only once</description>
+          <value>true</value>
+        </value-param>
+        <value-param>
+          <name>plugin.upgrade.async.execution</name>
+          <description>The plugin will be executed in an asynchronous mode</description>
+          <value>false</value>
+        </value-param>
+        <value-param>
+          <name>ownerType</name>
+          <description>The portalConfig ownerType to reload</description>
+          <value>portal</value>
+        </value-param>
+        <value-param>
+          <name>predefinedOwner</name>
+          <description>The portalConfig predefinerOwner to reload</description>
+          <value>global</value>
+        </value-param>
+        <value-param>
+          <name>location</name>
+          <description>The portalConfig location to reload</description>
+          <value>war:/conf/social-extension/portal/profile-page</value>
+        </value-param>
+        <value-param>
+          <name>importMode</name>
+          <description>The importMode to use</description>
+          <value>merge</value>
+        </value-param>
+        <value-param>
+          <name>overrideMode</name>
+          <description>The overrideMode to use</description>
+          <value>true</value>
+        </value-param>
+      </init-params>
+    </component-plugin>
+  </external-component-plugins>
 </configuration>

--- a/data-upgrade-pages/src/test/java/org/exoplatform/migration/ReloadPortalConfigurationMigrationTest.java
+++ b/data-upgrade-pages/src/test/java/org/exoplatform/migration/ReloadPortalConfigurationMigrationTest.java
@@ -1,0 +1,80 @@
+package org.exoplatform.migration;
+
+import org.exoplatform.container.xml.InitParams;
+import org.exoplatform.container.xml.ValueParam;
+import org.exoplatform.portal.config.UserPortalConfigService;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.junit.Assert.fail;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.times;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ReloadPortalConfigurationMigrationTest {
+
+  @Mock
+  UserPortalConfigService userPortalConfigService;
+
+  @Test
+  public void testProcessUpgrade() {
+    InitParams initParams = new InitParams();
+
+    ValueParam valueParam = new ValueParam();
+    String ownerType = "portal";
+    valueParam.setName("ownerType");
+    valueParam.setValue(ownerType);
+    initParams.addParameter(valueParam);
+
+    valueParam = new ValueParam();
+    String predefinedOwner="global";
+    valueParam.setName("predefinedOwner");
+    valueParam.setValue(predefinedOwner);
+    initParams.addParameter(valueParam);
+
+    valueParam = new ValueParam();
+    String location = "war:/conf/extension/portal";
+    valueParam.setName("location");
+    valueParam.setValue(location);
+    initParams.addParameter(valueParam);
+
+    valueParam = new ValueParam();
+    valueParam.setName("importMode");
+    String importMode="merge";
+    valueParam.setValue(importMode);
+    initParams.addParameter(valueParam);
+
+    valueParam = new ValueParam();
+    valueParam.setName("overrideMode");
+    String overrideMode="true";
+
+    valueParam.setValue(overrideMode);
+    initParams.addParameter(valueParam);
+
+    ReloadPortalConfigurationMigration reloadPortalConfigurationMigration = new ReloadPortalConfigurationMigration(userPortalConfigService,initParams);
+
+    reloadPortalConfigurationMigration.processUpgrade("v1","v2");
+    Mockito.verify(userPortalConfigService,times(1)).reloadConfig(ownerType,predefinedOwner,location,importMode,Boolean.parseBoolean(overrideMode));
+
+  }
+
+  @Test
+  public void testFailProcessUpgrade() {
+    InitParams initParams = new InitParams();
+
+
+    ReloadPortalConfigurationMigration reloadPortalConfigurationMigration = new ReloadPortalConfigurationMigration(userPortalConfigService,initParams);
+    try {
+      reloadPortalConfigurationMigration.processUpgrade("v1", "v2");
+      fail("Upgrade Plugin should not execute due to missing parameters");
+    } catch (RuntimeException re) {
+      //normal exception in this case
+    }
+    Mockito.verify(userPortalConfigService,times(0)).reloadConfig(anyString(),anyString(),anyString(),anyString(),anyBoolean());
+
+  }
+}


### PR DESCRIPTION
Before this fix, the page profile was modified in configuration and we need to reload it.
As it is only possible by properties, which not work correctly with different versions and customers, we create an UpgradePlugin to do it.