### PR TITLE
feat: Cleanup Test Classes and Dependencies - Meeds-io/MIPs#42 - EXO-62860

### DIFF
--- a/data-upgrade-news/src/test/java/org/exoplatform/news/upgrade/RemoveNewsRootNodeUpgradePluginTest.java
+++ b/data-upgrade-news/src/test/java/org/exoplatform/news/upgrade/RemoveNewsRootNodeUpgradePluginTest.java
@@ -27,8 +27,7 @@ import org.exoplatform.services.jcr.ext.common.SessionProvider;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.powermock.core.classloader.annotations.PowerMockIgnore;
-import org.powermock.modules.junit4.PowerMockRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import javax.jcr.Node;
 import javax.jcr.RepositoryException;
@@ -36,8 +35,7 @@ import javax.jcr.Session;
 
 import static org.mockito.Mockito.*;
 
-@RunWith(PowerMockRunner.class)
-@PowerMockIgnore({ "javax.management.*", "jdk.internal.reflect.*", "javax.xml.*", "org.apache.xerces.*", "org.xml.*" })
+@RunWith(MockitoJUnitRunner.class)
 public class RemoveNewsRootNodeUpgradePluginTest {
 
   @Mock


### PR DESCRIPTION
Prior to this change, the service testing was redefining lower layer configurations and was unstable due to the changes that may occur on base layers.