### PR TITLE
fix: Error while upgrading plugin with name 'DocumentsFavoritsPlugin' - EXO-62307

### DIFF
--- a/data-upgrade-processes-permissions/src/main/java/org/exoplatform/migration/ProcessesPermissionsMigration.java
+++ b/data-upgrade-processes-permissions/src/main/java/org/exoplatform/migration/ProcessesPermissionsMigration.java
@@ -75,8 +75,13 @@ public class ProcessesPermissionsMigration extends UpgradeProductPlugin {
     ExoContainerContext.setCurrentContainer(container);
     log.info("Start upgrade of processes permissions");
     boolean upgraded = false;
+    List<WorkFlowEntity> workflowsToUpdate = workFlowDAO.findAll();
+    if (workflowsToUpdate == null || workflowsToUpdate.isEmpty()) {
+      log.info("No processes permissions to be upgraded.");
+      return;
+    }
     List<WorkFlowEntity> updatedWorkflows = new ArrayList();
-    for (WorkFlowEntity workflowEntity : workFlowDAO.findAll()) {
+    for (WorkFlowEntity workflowEntity : workflowsToUpdate) {
       if (workflowEntity.getManager() == null || workflowEntity.getManager().isEmpty()
           || workflowEntity.getParticipator() == null || workflowEntity.getParticipator().isEmpty()) {
         Space space = getProjectParentSpace(workflowEntity.getProjectId());
@@ -100,7 +105,7 @@ public class ProcessesPermissionsMigration extends UpgradeProductPlugin {
     if (upgraded) {
       log.info("Processes permissions upgrade proceeded successfully. It took {} ms", (System.currentTimeMillis() - startupTime));
     } else {
-      throw new IllegalStateException("Documents favorites upgrade failed due to previous errors");
+      throw new IllegalStateException("Processes permissions upgrade failed due to previous errors");
     }
   }
 

--- a/data-upgrade-processes-permissions/src/main/java/org/exoplatform/migration/ProcessesPermissionsMigration.java
+++ b/data-upgrade-processes-permissions/src/main/java/org/exoplatform/migration/ProcessesPermissionsMigration.java
@@ -75,6 +75,7 @@ public class ProcessesPermissionsMigration extends UpgradeProductPlugin {
     ExoContainerContext.setCurrentContainer(container);
     log.info("Start upgrade of processes permissions");
     boolean upgraded = false;
+    boolean shouldUpgrade = true;
     List<WorkFlowEntity> workflowsToUpdate = workFlowDAO.findAll();
     if (workflowsToUpdate == null || workflowsToUpdate.isEmpty()) {
       log.info("No processes permissions to be upgraded.");
@@ -101,11 +102,17 @@ public class ProcessesPermissionsMigration extends UpgradeProductPlugin {
     if (!updatedWorkflows.isEmpty()) {
       workFlowDAO.updateAll(updatedWorkflows);
       upgraded = true;
+    } else {
+      shouldUpgrade = false;
     }
     if (upgraded) {
       log.info("Processes permissions upgrade proceeded successfully. It took {} ms", (System.currentTimeMillis() - startupTime));
     } else {
-      throw new IllegalStateException("Processes permissions upgrade failed due to previous errors");
+      if (!shouldUpgrade) {
+        log.info("No processes permissions to be upgraded");
+      } else {
+        throw new IllegalStateException("Processes permissions upgrade failed due to previous errors");
+      }
     }
   }
 


### PR DESCRIPTION
prior to this change, Error while upgrading-plugin with the name 'DocumentsFavoritsPlugin: "java.lang.IllegalStateException: Documents favorites upgrade failed due to previous errors" because no workflows were found to be updated so the upgraded attribute was always false since updatedWorkflows was empty
after this change, the upgrade plugin proceeds successfully when there is no workflow to upgrade with a log to inform that is empty

(cherry-picked from https://github.com/exoplatform/data-upgrade/pull/140)