### PR TITLE
fix: add singlePageApplication to DW hompage - EXO-62969

### DIFF
--- a/data-upgrade-pages/src/main/java/org/exoplatform/migration/AddCSSClassToPage.java
+++ b/data-upgrade-pages/src/main/java/org/exoplatform/migration/AddCSSClassToPage.java
@@ -1,0 +1,84 @@
+package org.exoplatform.migration;
+
+import org.apache.commons.lang3.StringUtils;
+import org.exoplatform.commons.upgrade.UpgradeProductPlugin;
+import org.exoplatform.container.PortalContainer;
+import org.exoplatform.container.component.RequestLifeCycle;
+import org.exoplatform.container.xml.InitParams;
+import org.exoplatform.portal.config.model.Container;
+import org.exoplatform.portal.config.model.ModelObject;
+import org.exoplatform.portal.config.model.Page;
+import org.exoplatform.portal.mop.SiteType;
+import org.exoplatform.portal.mop.page.PageKey;
+import org.exoplatform.portal.mop.storage.PageStorage;
+import org.exoplatform.services.log.ExoLogger;
+import org.exoplatform.services.log.Log;
+
+public class AddCSSClassToPage extends UpgradeProductPlugin {
+
+  private static final Log LOG          = ExoLogger.getExoLogger(AddCSSClassToPage.class);
+
+  private final PageStorage      pageStorage;
+
+  private String           cssClasses;
+
+  private String           siteName;
+
+  private String           pageName;
+
+  private String containerId;
+
+  public AddCSSClassToPage(PageStorage pageStorage, InitParams initParams) {
+    super(initParams);
+    this.pageStorage = pageStorage;
+    String siteNameParam = "site-name";
+    if (initParams.containsKey(siteNameParam) && !initParams.getValueParam(siteNameParam).getValue().isBlank()) {
+      siteName = initParams.getValueParam(siteNameParam).getValue();
+    }
+    String containerIdParam = "container-id";
+    if (initParams.containsKey(containerIdParam) && !initParams.getValueParam(containerIdParam).getValue().isBlank()) {
+      containerId = initParams.getValueParam(containerIdParam).getValue();
+    }
+    String cssClassesParam = "css-classes";
+    if (initParams.containsKey(cssClassesParam) && !initParams.getValueParam(cssClassesParam).getValue().isBlank()) {
+      cssClasses = initParams.getValueParam(cssClassesParam).getValue();
+    }
+    String pageNameParam = "page-name";
+    if (initParams.containsKey(pageNameParam) && !initParams.getValueParam(pageNameParam).getValue().isBlank()) {
+      pageName = initParams.getValueParam(pageNameParam).getValue();
+    }
+  }
+
+  @Override
+  public void processUpgrade(String oldVersion, String newVersion) {
+    LOG.info("Start upgrade : adding CSS class {} to {} page", cssClasses, pageName);
+
+    if (StringUtils.isBlank(siteName) || StringUtils.isBlank(pageName) || StringUtils.isBlank(containerId)
+        || StringUtils.isBlank(cssClasses)) {
+      LOG.warn("upgrade canceled : missing required parameters");
+      return;
+    }
+
+    long startupTime = System.currentTimeMillis();
+
+    PortalContainer portalContainer = PortalContainer.getInstance();
+    RequestLifeCycle.begin(portalContainer);
+
+    try {
+      Page page = pageStorage.getPage(new PageKey(SiteType.PORTAL.getName(), siteName, pageName));
+      for (ModelObject child : page.getChildren()) {
+        if (child instanceof Container container && containerId.equals(container.getId())) {
+          container.setCssClass(cssClasses);
+        }
+      }
+      pageStorage.save(page.build());
+    } catch (Exception e) {
+      LOG.error("Upgrade error : Failed to update the page {}", pageName, e);
+    } finally {
+      LOG.info("End upgrade : adding CSS class {} to {} page. It took {} ms",
+               cssClasses,
+               pageName,
+               (System.currentTimeMillis() - startupTime));
+    }
+  }
+}

--- a/data-upgrade-pages/src/main/java/org/exoplatform/migration/AddCSSClassToPage.java
+++ b/data-upgrade-pages/src/main/java/org/exoplatform/migration/AddCSSClassToPage.java
@@ -5,12 +5,11 @@ import org.exoplatform.commons.upgrade.UpgradeProductPlugin;
 import org.exoplatform.container.PortalContainer;
 import org.exoplatform.container.component.RequestLifeCycle;
 import org.exoplatform.container.xml.InitParams;
+import org.exoplatform.portal.config.DataStorage;
 import org.exoplatform.portal.config.model.Container;
 import org.exoplatform.portal.config.model.ModelObject;
 import org.exoplatform.portal.config.model.Page;
 import org.exoplatform.portal.mop.SiteType;
-import org.exoplatform.portal.mop.page.PageKey;
-import org.exoplatform.portal.mop.storage.PageStorage;
 import org.exoplatform.services.log.ExoLogger;
 import org.exoplatform.services.log.Log;
 
@@ -18,7 +17,7 @@ public class AddCSSClassToPage extends UpgradeProductPlugin {
 
   private static final Log LOG          = ExoLogger.getExoLogger(AddCSSClassToPage.class);
 
-  private final PageStorage      pageStorage;
+  private final DataStorage pageStorage;
 
   private String           cssClasses;
 
@@ -28,7 +27,7 @@ public class AddCSSClassToPage extends UpgradeProductPlugin {
 
   private String containerId;
 
-  public AddCSSClassToPage(PageStorage pageStorage, InitParams initParams) {
+  public AddCSSClassToPage(DataStorage pageStorage, InitParams initParams) {
     super(initParams);
     this.pageStorage = pageStorage;
     String siteNameParam = "site-name";
@@ -65,13 +64,13 @@ public class AddCSSClassToPage extends UpgradeProductPlugin {
     RequestLifeCycle.begin(portalContainer);
 
     try {
-      Page page = pageStorage.getPage(new PageKey(SiteType.PORTAL.getName(), siteName, pageName));
+      Page page = pageStorage.getPage(SiteType.PORTAL.getName() + "::" + siteName +"::" + pageName);
       for (ModelObject child : page.getChildren()) {
         if (child instanceof Container container && containerId.equals(container.getId())) {
           container.setCssClass(cssClasses);
         }
       }
-      pageStorage.save(page.build());
+      pageStorage.save(page);
     } catch (Exception e) {
       LOG.error("Upgrade error : Failed to update the page {}", pageName, e);
     } finally {

--- a/data-upgrade-pages/src/main/java/org/exoplatform/migration/PagesMigration.java
+++ b/data-upgrade-pages/src/main/java/org/exoplatform/migration/PagesMigration.java
@@ -108,6 +108,7 @@ public class PagesMigration extends UpgradeProductPlugin {
                  (System.currentTimeMillis() - startupTime));
         if (transactionStarted && entityManager.getTransaction().isActive()) {
           entityManager.getTransaction().commit();
+          entityManager.clear();
           entityManager.flush();
         }
       } catch (Exception e) {

--- a/data-upgrade-pages/src/main/resources/conf/portal/configuration.xml
+++ b/data-upgrade-pages/src/main/resources/conf/portal/configuration.xml
@@ -535,4 +535,60 @@
       </init-params>
     </component-plugin>
   </external-component-plugins>
+  <external-component-plugins>
+    <target-component>org.exoplatform.commons.upgrade.UpgradeProductService</target-component>
+    <component-plugin>
+      <name>AddCSSClassToSnapshotHomePage</name>
+      <set-method>addUpgradePlugin</set-method>
+      <type>org.exoplatform.migration.AddCSSClassToPage</type>
+      <description>Update SNAPSHOT page with a singlePageApplication css class</description>
+      <init-params>
+        <value-param>
+          <name>product.group.id</name>
+          <description>The groupId of the product</description>
+          <value>org.exoplatform.platform</value>
+        </value-param>
+        <value-param>
+          <name>plugin.upgrade.target.version</name>
+          <description>The plugin target version of selected groupId</description>
+          <value>6.4.0</value>
+        </value-param>
+        <value-param>
+          <name>plugin.execution.order</name>
+          <description>The plugin execution order</description>
+          <value>10</value>
+        </value-param>
+        <value-param>
+          <name>plugin.upgrade.execute.once</name>
+          <description>The plugin must be executed only once</description>
+          <value>true</value>
+        </value-param>
+        <value-param>
+          <name>plugin.upgrade.async.execution</name>
+          <description>The plugin will be executed in an asynchronous mode</description>
+          <value>false</value>
+        </value-param>
+        <value-param>
+          <name>site-name</name>
+          <description>The site name</description>
+          <value>dw</value>
+        </value-param>
+        <value-param>
+          <name>page-name</name>
+          <description>The page where to add the css class</description>
+          <value>homepage</value>
+        </value-param>
+        <value-param>
+          <name>container-id</name>
+          <description>The ID of the container</description>
+          <value>digitalWorkplaceHomePage</value>
+        </value-param>
+        <value-param>
+          <name>css-classes</name>
+          <description>List of CSS classes to add</description>
+          <value>singlePageApplication</value>
+        </value-param>
+      </init-params>
+    </component-plugin>
+  </external-component-plugins>
 </configuration>

--- a/data-upgrade-pages/src/test/java/org/exoplatform/migration/AddCSSClassToPageTest.java
+++ b/data-upgrade-pages/src/test/java/org/exoplatform/migration/AddCSSClassToPageTest.java
@@ -1,0 +1,69 @@
+package org.exoplatform.migration;
+
+import org.exoplatform.container.xml.InitParams;
+import org.exoplatform.container.xml.ValueParam;
+import org.exoplatform.portal.config.model.Container;
+import org.exoplatform.portal.config.model.ModelObject;
+import org.exoplatform.portal.config.model.Page;
+import org.exoplatform.portal.mop.SiteType;
+import org.exoplatform.portal.mop.page.PageKey;
+import org.exoplatform.portal.mop.storage.PageStorage;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class AddCSSClassToPageTest {
+
+  private PageStorage pageStorage;
+
+  @Before
+  public void setUp() throws Exception {
+    pageStorage = mock(PageStorage.class);
+  }
+
+  @Test
+  public void processUpgrade() {
+    InitParams initParams = new InitParams();
+    ValueParam siteParam = new ValueParam();
+    siteParam.setName("site-name");
+    siteParam.setValue("dw");
+    initParams.addParameter(siteParam);
+    ValueParam pageNameParam = new ValueParam();
+    pageNameParam.setName("page-name");
+    pageNameParam.setValue("homepage");
+    initParams.addParameter(pageNameParam);
+    ValueParam containerIdParam = new ValueParam();
+    containerIdParam.setName("container-id");
+    containerIdParam.setValue("homePageContainer");
+    initParams.addParameter(containerIdParam);
+    ValueParam cssClassesParam = new ValueParam();
+    cssClassesParam.setName("css-classes");
+    cssClassesParam.setValue("testClass firstClass");
+    initParams.addParameter(cssClassesParam);
+    Page homePage = mock(Page.class);
+    when(pageStorage.getPage(new PageKey(SiteType.PORTAL.getName(), "dw", "homepage"))).thenReturn(homePage);
+    Container firstContainer = new Container();
+    firstContainer.setId("homePageContainer");
+    Container secondContainer = new Container();
+    secondContainer.setId("footerContainer");
+    when(homePage.getChildren()).thenReturn(new ArrayList<>(List.of(firstContainer, secondContainer)));
+    AddCSSClassToPage addCSSClassToPage = new AddCSSClassToPage(pageStorage, initParams);
+    addCSSClassToPage.processUpgrade("v1", "v2");
+    verify(pageStorage, times(1)).save(homePage.build());
+    for(ModelObject c : homePage.getChildren()) {
+      if(((Container)c).getId().equals("homePageContainer")) {
+        assertEquals("testClass firstClass", ((Container)c).getCssClass());
+      } else {
+        assertNull(((Container)c).getCssClass());
+      }
+    }
+  }
+}

--- a/data-upgrade-pages/src/test/java/org/exoplatform/migration/AddCSSClassToPageTest.java
+++ b/data-upgrade-pages/src/test/java/org/exoplatform/migration/AddCSSClassToPageTest.java
@@ -2,12 +2,11 @@ package org.exoplatform.migration;
 
 import org.exoplatform.container.xml.InitParams;
 import org.exoplatform.container.xml.ValueParam;
+import org.exoplatform.portal.config.DataStorage;
 import org.exoplatform.portal.config.model.Container;
 import org.exoplatform.portal.config.model.ModelObject;
 import org.exoplatform.portal.config.model.Page;
 import org.exoplatform.portal.mop.SiteType;
-import org.exoplatform.portal.mop.page.PageKey;
-import org.exoplatform.portal.mop.storage.PageStorage;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -22,15 +21,15 @@ import static org.mockito.Mockito.*;
 @RunWith(MockitoJUnitRunner.class)
 public class AddCSSClassToPageTest {
 
-  private PageStorage pageStorage;
+  private DataStorage pageStorage;
 
   @Before
   public void setUp() throws Exception {
-    pageStorage = mock(PageStorage.class);
+    pageStorage = mock(DataStorage.class);
   }
 
   @Test
-  public void processUpgrade() {
+  public void processUpgrade() throws Exception {
     InitParams initParams = new InitParams();
     ValueParam siteParam = new ValueParam();
     siteParam.setName("site-name");
@@ -49,7 +48,7 @@ public class AddCSSClassToPageTest {
     cssClassesParam.setValue("testClass firstClass");
     initParams.addParameter(cssClassesParam);
     Page homePage = mock(Page.class);
-    when(pageStorage.getPage(new PageKey(SiteType.PORTAL.getName(), "dw", "homepage"))).thenReturn(homePage);
+    when(pageStorage.getPage(SiteType.PORTAL.getName() + "::" + "dw" + "::" + "homepage")).thenReturn(homePage);
     Container firstContainer = new Container();
     firstContainer.setId("homePageContainer");
     Container secondContainer = new Container();
@@ -57,7 +56,7 @@ public class AddCSSClassToPageTest {
     when(homePage.getChildren()).thenReturn(new ArrayList<>(List.of(firstContainer, secondContainer)));
     AddCSSClassToPage addCSSClassToPage = new AddCSSClassToPage(pageStorage, initParams);
     addCSSClassToPage.processUpgrade("v1", "v2");
-    verify(pageStorage, times(1)).save(homePage.build());
+    verify(pageStorage, times(1)).save(homePage);
     for(ModelObject c : homePage.getChildren()) {
       if(((Container)c).getId().equals("homePageContainer")) {
         assertEquals("testClass firstClass", ((Container)c).getCssClass());


### PR DESCRIPTION
this upgrade plugin could be used to add new css classes to some predefined containers in a page. it is used in this fix to add the css class singlePageApplication to the homepage of the DW site