### PR TITLE
fix: After migration to 6.5.x, all pages of /platform/administrators group navigation are no more accessible - EXO-63549

### DIFF
--- a/data-upgrade-navigations/src/main/java/org/exoplatform/migration/PortalConfigPermissionMigration.java
+++ b/data-upgrade-navigations/src/main/java/org/exoplatform/migration/PortalConfigPermissionMigration.java
@@ -1,0 +1,89 @@
+package org.exoplatform.migration;
+
+import org.exoplatform.commons.persistence.impl.EntityManagerService;
+import org.exoplatform.commons.upgrade.UpgradeProductPlugin;
+import org.exoplatform.container.ExoContainerContext;
+import org.exoplatform.container.PortalContainer;
+import org.exoplatform.container.component.RequestLifeCycle;
+import org.exoplatform.container.xml.InitParams;
+import org.exoplatform.portal.jdbc.entity.PermissionEntity;
+import org.exoplatform.portal.jdbc.entity.SiteEntity;
+import org.exoplatform.services.log.ExoLogger;
+import org.exoplatform.services.log.Log;
+
+import javax.persistence.EntityManager;
+import javax.persistence.Query;
+import javax.persistence.TypedQuery;
+import java.util.List;
+
+public class PortalConfigPermissionMigration  extends UpgradeProductPlugin {
+    private final PortalContainer      container;
+
+    private final EntityManagerService entityManagerService;
+    private static final Log LOG                        = ExoLogger.getExoLogger(PortalConfigPermissionMigration.class);
+
+    public PortalConfigPermissionMigration(PortalContainer container,
+                                    EntityManagerService entityManagerService,
+                                    InitParams initParams) {
+        super(initParams);
+        this.container = container;
+        this.entityManagerService = entityManagerService;
+
+    }
+    @Override
+    public void processUpgrade(String s, String s1) {
+        long startupTime = System.currentTimeMillis();
+
+        ExoContainerContext.setCurrentContainer(container);
+        boolean transactionStarted = false;
+
+        LOG.info("Start upgrade of permission for portalConfiguration");
+        RequestLifeCycle.begin(this.entityManagerService);
+        EntityManager entityManager = this.entityManagerService.getEntityManager();
+        try {
+            if (!entityManager.getTransaction().isActive()) {
+                entityManager.getTransaction().begin();
+                transactionStarted = true;
+            }
+            String sqlString1 ="SELECT p FROM GateInPermission p WHERE p.permission LIKE '%@owner@%'";
+            TypedQuery<PermissionEntity> nativeQuery1= entityManager.createQuery(sqlString1, PermissionEntity.class);
+            List<PermissionEntity> resultList = nativeQuery1.getResultList();
+
+            resultList.forEach(permissionEntity -> {
+                Long portalConfigId = permissionEntity.getReferenceId();
+                String sqlString2 ="SELECT s FROM GateInSite s where s.id=:siteId";
+                TypedQuery<SiteEntity> nativeQuery2 = entityManager.createQuery(sqlString2, SiteEntity.class);
+                nativeQuery2.setParameter("siteId",portalConfigId);
+                SiteEntity site = nativeQuery2.getSingleResult();
+                String name = site.getName();
+
+                String permission = permissionEntity.getPermission().replace("@owner@", name);
+
+                String updateQuery = "UPDATE PORTAL_PERMISSIONS SET PERMISSION = :permission WHERE PERMISSION_ID=:permissionId";
+                Query updateNativeQuery = entityManager.createNativeQuery(updateQuery);
+                updateNativeQuery.setParameter("permission",permission);
+                updateNativeQuery.setParameter("permissionId",permissionEntity.getId());
+
+                updateNativeQuery.executeUpdate();
+                LOG.info("Update permission from {} to {} for portalConfig {}",permissionEntity.getPermission(), permission, name);
+
+            });
+
+
+            LOG.info("End upgrade of of permission for portalConfiguration. It took {} ms",
+                    (System.currentTimeMillis() - startupTime));
+
+            if (transactionStarted && entityManager.getTransaction().isActive()) {
+                entityManager.getTransaction().commit();
+            }
+
+        } catch (Exception e) {
+            if (transactionStarted && entityManager.getTransaction().isActive() && entityManager.getTransaction().getRollbackOnly()) {
+                entityManager.getTransaction().rollback();
+            }
+            throw new RuntimeException("Unable to update PortalSite",e);
+        } finally {
+            RequestLifeCycle.end();
+        }
+    }
+}

--- a/data-upgrade-navigations/src/main/resources/conf/portal/configuration.xml
+++ b/data-upgrade-navigations/src/main/resources/conf/portal/configuration.xml
@@ -119,5 +119,40 @@
         </value-param>
       </init-params>
     </component-plugin>
+    <component-plugin>
+      <name>PortalConfigPermissionNavigationPlugin</name>
+      <set-method>addUpgradePlugin</set-method>
+      <type>org.exoplatform.migration.PortalConfigPermissionMigration</type>
+      <description>Replaces old @owner@ permission by the correct one</description>
+      <init-params>
+        <value-param>
+          <name>product.group.id</name>
+          <description>The groupId of the product</description>
+          <value>org.exoplatform.platform</value>
+        </value-param>
+        <value-param>
+          <name>plugin.upgrade.target.version</name>
+          <description>The plugin target version of selected groupId</description>
+          <value>6.5.0</value>
+        </value-param>
+        <value-param>
+          <name>plugin.execution.order</name>
+          <description>The plugin execution order</description>
+          <value>10</value>
+        </value-param>
+        <value-param>
+          <name>plugin.upgrade.execute.once</name>
+          <description>The plugin must be executed only once</description>
+          <value>true</value>
+        </value-param>
+        <value-param>
+          <name>plugin.upgrade.async.execution</name>
+          <description>The plugin will be executed in an asynchronous mode</description>
+          <value>true</value>
+        </value-param>
+      </init-params>
+    </component-plugin>
   </external-component-plugins>
+
+
 </configuration>

--- a/data-upgrade-navigations/src/test/java/org/exoplatform/migration/PortalConfigPermissionMigrationTest.java
+++ b/data-upgrade-navigations/src/test/java/org/exoplatform/migration/PortalConfigPermissionMigrationTest.java
@@ -1,0 +1,155 @@
+package org.exoplatform.migration;
+
+import org.exoplatform.commons.persistence.impl.EntityManagerService;
+import org.exoplatform.commons.upgrade.UpgradePluginExecutionContext;
+import org.exoplatform.commons.utils.CommonsUtils;
+import org.exoplatform.component.test.AbstractKernelTest;
+import org.exoplatform.component.test.ConfigurationUnit;
+import org.exoplatform.component.test.ConfiguredBy;
+import org.exoplatform.component.test.ContainerScope;
+import org.exoplatform.container.ExoContainerContext;
+import org.exoplatform.container.PortalContainer;
+import org.exoplatform.container.component.RequestLifeCycle;
+import org.exoplatform.container.xml.InitParams;
+import org.exoplatform.container.xml.ValueParam;
+import org.exoplatform.portal.config.model.PortalConfig;
+import org.exoplatform.portal.jdbc.entity.NodeEntity;
+import org.exoplatform.portal.jdbc.entity.PermissionEntity;
+import org.exoplatform.portal.jdbc.entity.SiteEntity;
+import org.exoplatform.portal.mop.SiteKey;
+import org.exoplatform.portal.mop.SiteType;
+import org.exoplatform.portal.mop.dao.NodeDAO;
+import org.exoplatform.portal.mop.dao.PermissionDAO;
+import org.exoplatform.portal.mop.dao.SiteDAO;
+import org.exoplatform.portal.mop.navigation.*;
+import org.exoplatform.portal.mop.service.LayoutService;
+import org.exoplatform.portal.mop.service.NavigationService;
+import org.exoplatform.portal.pom.data.ContainerData;
+import org.exoplatform.portal.pom.data.PortalData;
+import org.exoplatform.services.cache.CacheService;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+@ConfiguredBy({
+        @ConfigurationUnit(scope = ContainerScope.ROOT, path = "conf/configuration.xml"),
+        @ConfigurationUnit(scope = ContainerScope.PORTAL, path = "conf/portal/configuration.xml"),
+        @ConfigurationUnit(scope = ContainerScope.PORTAL, path = "conf/exo.portal.component.portal-configuration-local.xml"),
+        @ConfigurationUnit(scope = ContainerScope.PORTAL, path = "org/exoplatform/portal/config/conf/configuration.xml"),
+})
+public class PortalConfigPermissionMigrationTest extends AbstractKernelTest {
+
+    protected PortalContainer container;
+
+    protected NavigationService navigationService;
+
+    protected LayoutService layoutService;
+
+    protected EntityManagerService entityManagerService;
+
+    protected NavigationContext nav;
+
+    @Before
+    public void setUp() throws Exception {
+
+        container = PortalContainer.getInstance();
+        navigationService = container.getComponentInstanceOfType(NavigationService.class);
+        layoutService = container.getComponentInstanceOfType(LayoutService.class);
+        entityManagerService = container.getComponentInstanceOfType(EntityManagerService.class);
+
+        begin();
+        injectData();
+    }
+    @After
+    public void tearDown() {
+        purgeData();
+        end();
+    }
+    protected void injectData() throws Exception {
+
+        this.createSite(SiteType.GROUP, "/my_group_name");
+
+        nav = navigationService.loadNavigation(SiteKey.group("/my_group_name"));
+
+    }
+
+    protected void purgeData() {
+        navigationService.destroyNavigation(nav);
+    }
+
+    protected void begin() {
+        ExoContainerContext.setCurrentContainer(container);
+        RequestLifeCycle.begin(container);
+    }
+
+    protected void end() {
+        RequestLifeCycle.end();
+    }
+
+    protected void createSite(SiteType type, String siteName) throws Exception {
+
+        List<String> accessPermission = new ArrayList<>();
+        accessPermission.add("@owner@");
+
+        ContainerData container = new ContainerData(null,
+                "testcontainer_" + siteName,
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                Collections.emptyList(),
+                Collections.emptyList(),
+                Collections.emptyList(),
+                Collections.emptyList());
+        PortalData portal = new PortalData(null,
+                siteName,
+                type.getName(),
+                null,
+                null,
+                null,
+                accessPermission,
+                "manager:@owner@",
+                null,
+                null,
+                container,
+                null);
+        this.layoutService.create(new PortalConfig(portal));
+
+        NavigationContext navigation = new NavigationContext(type.key(siteName), new NavigationState(1));
+        navigationService.saveNavigation(navigation);
+    }
+
+
+
+    @Test
+    public void testSiteConfigMigration() {
+        InitParams initParams = new InitParams();
+        PortalConfigPermissionMigration portalConfigPermissionMigration = new PortalConfigPermissionMigration(container, entityManagerService,initParams);
+        portalConfigPermissionMigration.processUpgrade(null, null);
+        end();
+        begin();
+
+        SiteDAO siteDAO = CommonsUtils.getService(SiteDAO.class);
+        SiteEntity site = siteDAO.findByKey(new SiteKey(SiteType.GROUP,"/my_group_name"));
+        assertNotNull(site);
+
+        PermissionDAO permissionDAO = CommonsUtils.getService(PermissionDAO.class);
+        List<PermissionEntity> accessPermissionEntityList = permissionDAO.getPermissions(SiteEntity.class.getName(),site.getId(), PermissionEntity.TYPE.ACCESS);
+        List<PermissionEntity> editPermission = permissionDAO.getPermissions(SiteEntity.class.getName(),site.getId(), PermissionEntity.TYPE.EDIT);
+
+        assertEquals(1, accessPermissionEntityList.size());
+        assertEquals("/my_group_name", accessPermissionEntityList.get(0).getPermission());
+        assertEquals(1, editPermission.size());
+        assertEquals("manager:/my_group_name", editPermission.get(0).getPermission());
+    }
+}


### PR DESCRIPTION
Before this fix, the permission for SiteEntity /platform/navigation was @owner@ in tribe This comes from old time when we defined a Portal with file group.xml. With this, when checking if a user a editPermission or readPermission, we always have a false, and associated pages a so inaccessible. This fix is a data-upgrade which will modify @owner@ to correct permission (we take the SiteConfig name which correspond to the groupId).