### PR TITLE
feat: introduce eXo parent pom - EXO-64103

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.exoplatform.addons</groupId>
     <artifactId>addons-exo-parent-pom</artifactId>
-    <version>17-security-fix-SNAPSHOT</version>
+    <version>17-M01</version>
     <relativePath/>
   </parent>
   <groupId>org.exoplatform.addons.upgrade</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,8 +4,8 @@
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.exoplatform.addons</groupId>
-    <artifactId>addons-parent-pom</artifactId>
-    <version>17-exo-M01</version>
+    <artifactId>addons-parent-exo-pom</artifactId>
+    <version>17-security-fix-SNAPSHOT</version>
     <relativePath/>
   </parent>
   <groupId>org.exoplatform.addons.upgrade</groupId>
@@ -36,15 +36,9 @@
   </modules>
   <properties>
     <!-- 3rd party libraries versions -->
-    <org.exoplatform.commons.version>6.5.x-exo-SNAPSHOT</org.exoplatform.commons.version>
-    <org.exoplatform.social.version>6.5.x-exo-SNAPSHOT</org.exoplatform.social.version>
     <addon.exo.ecms.version>6.5.x-SNAPSHOT</addon.exo.ecms.version>
-    <addon.exo.notes.version>1.3.x-exo-SNAPSHOT</addon.exo.notes.version>
-    <addon.exo.jcr.version>6.5.x-SNAPSHOT</addon.exo.jcr.version>
     <addon.exo.news.version>2.5.x-SNAPSHOT</addon.exo.news.version>
     <addon.exo.processes.version>1.2.x-SNAPSHOT</addon.exo.processes.version>
-    <addon.exo.tasks.version>3.5.x-exo-SNAPSHOT</addon.exo.tasks.version>
-    <addon.exo.analytics.version>1.4.x-exo-SNAPSHOT</addon.exo.analytics.version>
 
     <!-- Sonar properties -->
     <sonar.organization>exoplatform</sonar.organization>
@@ -53,41 +47,13 @@
     <dependencies>
       <!-- Import versions from platform project -->
       <dependency>
-        <groupId>org.exoplatform.commons</groupId>
-        <artifactId>commons</artifactId>
-        <version>${org.exoplatform.commons.version}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.exoplatform.social</groupId>
-        <artifactId>social</artifactId>
-        <version>${org.exoplatform.social.version}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.exoplatform.addons.notes</groupId>
-        <artifactId>notes</artifactId>
-        <version>${addon.exo.notes.version}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-      <dependency>
         <groupId>org.exoplatform.ecms</groupId>
         <artifactId>ecms</artifactId>
         <version>${addon.exo.ecms.version}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
-      <dependency>
-        <groupId>org.exoplatform.addons.analytics</groupId>
-        <artifactId>analytics-parent</artifactId>
-        <version>${addon.exo.analytics.version}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-	  
+
       <!-- News dependencies -->
       <dependency>
         <groupId>org.exoplatform.addons.news</groupId>
@@ -102,23 +68,6 @@
         <groupId>org.exoplatform.processes</groupId>
         <artifactId>processes-parent</artifactId>
         <version>${addon.exo.processes.version}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-
-      <dependency>
-        <groupId>org.exoplatform.addons.task</groupId>
-        <artifactId>task-management-parent</artifactId>
-        <version>${addon.exo.tasks.version}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-
-      <!-- JCR dependencies -->
-      <dependency>
-        <groupId>org.exoplatform.jcr</groupId>
-        <artifactId>jcr-parent</artifactId>
-        <version>${addon.exo.jcr.version}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.exoplatform.addons</groupId>
-    <artifactId>addons-parent-exo-pom</artifactId>
+    <artifactId>addons-exo-parent-pom</artifactId>
     <version>17-security-fix-SNAPSHOT</version>
     <relativePath/>
   </parent>


### PR DESCRIPTION
This feature introduce new parent pom for eXo to be able to declare libraries versions used only in eXo, without impacting meeds