### PR TITLE
fix : After upgrading from Exo 6.3.4 to Exo 6.4.x the People Advanced Search doesn't list all the searched users - EXO-64127 - Meeds-io/meeds#1057

### DIFF
--- a/data-upgrade-es-reindex/src/main/java/org/exoplatform/elastic/upgrade/ElasticsearchMigration.java
+++ b/data-upgrade-es-reindex/src/main/java/org/exoplatform/elastic/upgrade/ElasticsearchMigration.java
@@ -72,9 +72,9 @@ public class ElasticsearchMigration extends UpgradeProductPlugin {
             + ", response code = " + response.getStatusCode() + " message = " + response.getMessage());
       } else {
         LOG.info("Reindexation finished for index  from old index {} to new index {}", oldIndex, newIndex);
-        LOG.info("START::Delete files index {}", oldIndex);
+        LOG.info("START::Delete profiles index {}", oldIndex);
         analyticsESClient.sendHttpDeleteRequest(oldIndex);
-        LOG.info("END::Delete old files index {} successfully", oldIndex);
+        LOG.info("END::Delete old profiles index {} successfully", oldIndex);
         LOG.info("END::Index '{}' migration to {} successfully. The operation took {} milliseconds.",
                  oldIndex,
                  newIndex,

--- a/data-upgrade-es-reindex/src/main/resources/conf/portal/configuration.xml
+++ b/data-upgrade-es-reindex/src/main/resources/conf/portal/configuration.xml
@@ -36,8 +36,8 @@
         </value-param>
         <value-param>
           <name>plugin.upgrade.target.version</name>
-          <description>The plugin target version (will not be executed if previous version is equal or higher than 6.3.0)</description>
-          <value>6.3.0</value>
+          <description>The plugin target version</description>
+          <value>6.5.0</value>
         </value-param>
         <value-param>
           <name>plugin.execution.order</name>
@@ -57,12 +57,12 @@
         <value-param>
           <name>oldIndex</name>
           <description>Old index name</description>
-          <value>${exo.upgrade.reindex.old.index:}</value>
+          <value>profile_v2 </value>
         </value-param>
         <value-param>
           <name>newIndex</name>
           <description>New index name</description>
-          <value>${exo.upgrade.reindex.new.index:}</value>
+          <value>profile_v3</value>
         </value-param>
       </init-params>
     </component-plugin>


### PR DESCRIPTION

Prior to this change, when upgrading from Exo 6.3.4 to Exo 6.4.x, the People Advanced Search wouldn't list all the searched users. The issue was that the profile property settings were not indexed in Exo 6.3.4. With this change, the user profiles will be reindexed.