### PR TITLE
fix: move image storage location of News & Notes - EXO-64344

### DIFF
--- a/data-upgrade-move-folders/pom.xml
+++ b/data-upgrade-move-folders/pom.xml
@@ -1,0 +1,52 @@
+<!-- Copyright (C) 2023 eXo Platform SAS. This is free software; you can
+  redistribute it and/or modify it under the terms of the GNU Lesser General 
+  Public License as published by the Free Software Foundation; either version 
+  2.1 of the License, or (at your option) any later version. This software 
+  is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; 
+  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR 
+  PURPOSE. See the GNU Lesser General Public License for more details. You 
+  should have received a copy of the GNU Lesser General Public License along 
+  with this software; if not, write to the Free Software Foundation, Inc., 
+  51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA, or see the FSF site: 
+  http://www.fsf.org. -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.exoplatform.addons.upgrade</groupId>
+    <artifactId>upgrade</artifactId>
+    <version>6.5.x-maintenance-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>data-upgrade-move-folders</artifactId>
+  <packaging>jar</packaging>
+  <name>eXo Add-on:: Data Upgrade Add-on - Move Folders</name>
+
+  <properties>
+    <exo.test.coverage.ratio>0.0</exo.test.coverage.ratio>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.exoplatform.commons</groupId>
+      <artifactId>commons-component-upgrade</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.exoplatform.jcr</groupId>
+      <artifactId>exo.jcr.component.core</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.exoplatform.jcr</groupId>
+      <artifactId>exo.jcr.component.ext</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.exoplatform.ecms</groupId>
+      <artifactId>ecms-core-services</artifactId>
+      <scope>provided</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/data-upgrade-move-folders/src/main/java/org/exoplatform/jcr/upgrade/MoveNodesUpgradePlugin.java
+++ b/data-upgrade-move-folders/src/main/java/org/exoplatform/jcr/upgrade/MoveNodesUpgradePlugin.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright (C) 2003-2023 eXo Platform SAS
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <gnu.org/licenses>.
+ */
+package org.exoplatform.jcr.upgrade;
+
+import javax.jcr.Item;
+import javax.jcr.RepositoryException;
+import javax.jcr.Session;
+
+import org.apache.commons.lang3.StringUtils;
+import org.exoplatform.commons.upgrade.UpgradeProductPlugin;
+import org.exoplatform.commons.utils.ListAccess;
+import org.exoplatform.container.PortalContainer;
+import org.exoplatform.container.component.RequestLifeCycle;
+import org.exoplatform.container.xml.InitParams;
+import org.exoplatform.services.jcr.RepositoryService;
+import org.exoplatform.services.jcr.ext.app.SessionProviderService;
+import org.exoplatform.services.jcr.ext.common.SessionProvider;
+import org.exoplatform.services.log.ExoLogger;
+import org.exoplatform.services.log.Log;
+import org.exoplatform.social.core.space.model.Space;
+import org.exoplatform.social.core.space.spi.SpaceService;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * plugin will be executed in order to move folders under spaces drives
+ * from an original path to a destination path as provided in the configuration
+ */
+public class MoveNodesUpgradePlugin extends UpgradeProductPlugin {
+
+  private static final Log       log                     = ExoLogger.getLogger(MoveNodesUpgradePlugin.class.getName());
+
+  private static final String    ORIGIN_PATH      = "origin-folder-path";
+
+  private static final String    DESTINATION_PATH = "destination-folder-path";
+  private static final String    FOLDERS_TO_REMOVE = "folders-to-remove";
+
+  private static final int       SPACES_PAGE_SIZE  = 2;
+
+  private final SpaceService     spaceService;
+
+  private RepositoryService      repositoryService;
+
+  private SessionProviderService sessionProviderService;
+
+  private String                 originPath;
+
+  private String                 destinationPath;
+
+  private List<String>           foldersToRemove   = new ArrayList<>();
+
+
+  public MoveNodesUpgradePlugin(InitParams initParams,
+                                SpaceService spaceService,
+                                RepositoryService repositoryService,
+                                SessionProviderService sessionProviderService) {
+    super(initParams);
+    if(initParams.getValueParam(ORIGIN_PATH) != null && StringUtils.isNotBlank(initParams.getValueParam(ORIGIN_PATH).getValue())) {
+      this.originPath = initParams.getValueParam(ORIGIN_PATH).getValue();
+    }
+    if(initParams.getValueParam(ORIGIN_PATH) != null && StringUtils.isNotBlank(initParams.getValueParam(ORIGIN_PATH).getValue())) {
+      this.destinationPath = initParams.getValueParam(DESTINATION_PATH).getValue();
+    }
+    if(initParams.getValuesParam(FOLDERS_TO_REMOVE) != null && !initParams.getValuesParam(FOLDERS_TO_REMOVE).getValues().isEmpty()) {
+      this.foldersToRemove = initParams.getValuesParam(FOLDERS_TO_REMOVE).getValues();
+    }
+
+    this.spaceService = spaceService;
+    this.repositoryService = repositoryService;
+    this.sessionProviderService = sessionProviderService;
+  }
+
+  @Override
+  public void processUpgrade(String oldVersion, String newVersion) {
+    if(StringUtils.isBlank(originPath) || StringUtils.isBlank(destinationPath)) {
+      log.warn("Invalid parameter was provided for {}, this upgrade plugin will be ignored", StringUtils.isBlank(originPath) ? "'Origin path'":"'Destination path'");
+      return;
+    }
+    long startupTime = System.currentTimeMillis();
+    int movedFoldersCount = 0;
+    log.info("Start upgrade : Moving of folder from {} to {}", originPath, destinationPath);
+
+    SessionProvider sessionProvider = null;
+    RequestLifeCycle.begin(PortalContainer.getInstance());
+    try {
+      sessionProvider = sessionProviderService.getSystemSessionProvider(null);
+      Session session = sessionProvider.getSession(
+              repositoryService.getCurrentRepository()
+                      .getConfiguration()
+                      .getDefaultWorkspaceName(),
+              repositoryService.getCurrentRepository());
+      ListAccess<Space> spaces = spaceService.getAllSpacesWithListAccess();
+      int index = 0;
+      while(index <= spaces.getSize()) {
+        Space[] spaceArray = spaces.load(index, SPACES_PAGE_SIZE);
+        for (Space space : spaceArray) {
+          String originFolderPath = "/Groups" + space.getGroupId() + originPath;
+          String destinationFolderPath = "/Groups" + space.getGroupId() + destinationPath;
+          Item originFolderNode = session.getItem(originFolderPath);
+          if(originFolderNode != null) {
+            session.move(originFolderPath, destinationFolderPath);
+            movedFoldersCount ++;
+          }
+          // remove unnecessary folders if defined in init params
+          if(!foldersToRemove.isEmpty()) {
+            for(String folderToRemove : foldersToRemove) {
+              folderToRemove = "/Groups" + space.getGroupId() + folderToRemove;
+              try {
+                Item folderToRemoveNode = session.getItem(folderToRemove);
+                if (folderToRemoveNode != null) {
+                  folderToRemoveNode.remove();
+                }
+              } catch (RepositoryException re) {
+                log.warn("Folder {} to delete was not found, ignoring it", folderToRemove, re);
+              }
+            }
+          }
+        }
+
+        session.save();
+        index = index + SPACES_PAGE_SIZE;
+      }
+
+      log.info("End Moving of '{}' folders. It took {} ms",
+              movedFoldersCount,
+              (System.currentTimeMillis() - startupTime));
+    } catch (Exception e) {
+      if (log.isErrorEnabled()) {
+        log.error("An unexpected error occurs when moving folders:", e);
+      }
+    } finally {
+      if (sessionProvider != null) {
+        sessionProvider.close();
+      }
+      RequestLifeCycle.end();
+    }
+  }
+
+}

--- a/data-upgrade-move-folders/src/main/resources/conf/portal/configuration.xml
+++ b/data-upgrade-move-folders/src/main/resources/conf/portal/configuration.xml
@@ -1,0 +1,125 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (C) 2023 eXo Platform SAS.
+
+    This is free software; you can redistribute it and/or modify it
+    under the terms of the GNU Lesser General Public License as
+    published by the Free Software Foundation; either version 2.1 of
+    the License, or (at your option) any later version.
+
+    This software is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+    Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public
+    License along with this software; if not, write to the Free
+    Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+    02110-1301 USA, or see the FSF site: http://www.fsf.org.
+
+-->
+
+
+<configuration xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.exoplatform.org/xml/ns/kernel_1_2.xsd http://www.exoplatform.org/xml/ns/kernel_1_2.xsd"
+  xmlns="http://www.exoplatform.org/xml/ns/kernel_1_2.xsd">
+
+  <external-component-plugins>
+    <target-component>org.exoplatform.commons.upgrade.UpgradeProductService</target-component>
+    <component-plugin profiles="news">
+      <name>MoveNewsFolderToSpaceRoot</name>
+      <set-method>addUpgradePlugin</set-method>
+      <type>org.exoplatform.jcr.upgrade.MoveNodesUpgradePlugin</type>
+      <description>Move images attached to News to a new location</description>
+      <init-params>
+        <value-param>
+          <name>product.group.id</name>
+          <description>The groupId of the product</description>
+          <value>org.exoplatform.news</value>
+        </value-param>
+        <value-param>
+          <name>plugin.execution.order</name>
+          <description>The plugin execution order</description>
+          <value>1</value>
+        </value-param>
+        <value-param>
+          <name>plugin.upgrade.execute.once</name>
+          <description>Execute this upgrade plugin only once</description>
+          <value>true</value>
+        </value-param>
+        <value-param>
+          <name>plugin.upgrade.async.execution</name>
+          <description>Execute this upgrade asynchronously</description>
+          <value>true</value>
+        </value-param>
+        <value-param>
+          <name>plugin.upgrade.target.version</name>
+          <description>Target version of the plugin</description>
+          <value>6.5.0</value>
+        </value-param>
+        <!-- Configuration parameters specific to the current upgrade plugin -->
+        <value-param>
+          <name>origin-folder-path</name>
+          <description>Origin folder path</description>
+          <value>/Documents/news/images</value>
+        </value-param>
+        <value-param>
+          <name>destination-folder-path</name>
+          <description>Destination parent folder path</description>
+          <value>/News/images</value>
+        </value-param>
+        <values-param>
+          <name>folders-to-remove</name>
+          <value>/Documents/news</value>
+        </values-param>
+      </init-params>
+    </component-plugin>
+    <component-plugin profiles="news">
+      <name>MoveNotesFolderToSpaceRoot</name>
+      <set-method>addUpgradePlugin</set-method>
+      <type>org.exoplatform.jcr.upgrade.MoveNodesUpgradePlugin</type>
+      <description>Move images attached to notes to a new location</description>
+      <init-params>
+        <value-param>
+          <name>product.group.id</name>
+          <description>The groupId of the product</description>
+          <value>org.meeds-io.notes</value>
+        </value-param>
+        <value-param>
+          <name>plugin.execution.order</name>
+          <description>The plugin execution order</description>
+          <value>1</value>
+        </value-param>
+        <value-param>
+          <name>plugin.upgrade.execute.once</name>
+          <description>Execute this upgrade plugin only once</description>
+          <value>true</value>
+        </value-param>
+        <value-param>
+          <name>plugin.upgrade.async.execution</name>
+          <description>Execute this upgrade asynchronously</description>
+          <value>true</value>
+        </value-param>
+        <value-param>
+          <name>plugin.upgrade.target.version</name>
+          <description>Target version of the plugin</description>
+          <value>6.5.0</value>
+        </value-param>
+        <!-- Configuration parameters specific to the current upgrade plugin -->
+        <value-param>
+          <name>origin-folder-path</name>
+          <description>Origin folder path</description>
+          <value>/Documents/notes</value>
+        </value-param>
+        <value-param>
+          <name>destination-folder-path</name>
+          <description>Destination parent folder path</description>
+          <value>/notes</value>
+        </value-param>
+      </init-params>
+    </component-plugin>
+
+  </external-component-plugins>
+</configuration>
+

--- a/data-upgrade-move-folders/src/test/java/org/exoplatform/jcr/upgrade/MoveNodesUpgradePluginTest.java
+++ b/data-upgrade-move-folders/src/test/java/org/exoplatform/jcr/upgrade/MoveNodesUpgradePluginTest.java
@@ -1,0 +1,109 @@
+package org.exoplatform.jcr.upgrade;
+
+import org.exoplatform.commons.utils.ListAccess;
+import org.exoplatform.container.xml.InitParams;
+import org.exoplatform.container.xml.ValueParam;
+import org.exoplatform.services.jcr.RepositoryService;
+import org.exoplatform.services.jcr.config.RepositoryEntry;
+import org.exoplatform.services.jcr.core.ManageableRepository;
+import org.exoplatform.services.jcr.ext.app.SessionProviderService;
+import org.exoplatform.services.jcr.ext.common.SessionProvider;
+import org.exoplatform.social.core.space.SpaceListAccess;
+import org.exoplatform.social.core.space.model.Space;
+import org.exoplatform.social.core.space.spi.SpaceService;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import javax.jcr.Item;
+import javax.jcr.Session;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class MoveNodesUpgradePluginTest {
+  @Mock
+  private RepositoryService repositoryService;
+
+  @Mock
+  private SessionProviderService sessionProviderService;
+
+  @Mock
+  private ManageableRepository repository;
+
+  @Mock
+  private RepositoryEntry repositoryEntry;
+
+  @Mock
+  private SessionProvider sessionProvider;
+
+  @Mock
+  private Session session;
+
+  @Mock
+  private SpaceService spaceService;
+
+  @Before
+  public void setUp() throws Exception {
+    lenient().when(sessionProviderService.getSystemSessionProvider(any())).thenReturn(sessionProvider);
+    lenient().when(repositoryService.getCurrentRepository()).thenReturn(repository);
+    lenient().when(repository.getConfiguration()).thenReturn(repositoryEntry);
+    lenient().when(repositoryEntry.getDefaultWorkspaceName()).thenReturn("collaboration");
+    Item node = mock(Item.class);
+    when(session.getItem(anyString())).thenReturn(node);
+    lenient().when(sessionProvider.getSession(any(), any(ManageableRepository.class))).thenReturn(session);
+  }
+
+  @Test
+  public void testMoveFoldersUpgrade() throws Exception {
+    InitParams initParams = new InitParams();
+
+    ValueParam valueParam = new ValueParam();
+    valueParam.setName("product.group.id");
+    valueParam.setValue("org.exoplatform.platform");
+    initParams.addParameter(valueParam);
+
+    MoveNodesUpgradePlugin plugin = new MoveNodesUpgradePlugin(initParams,
+            spaceService,
+            repositoryService,
+            sessionProviderService);
+    plugin.processUpgrade(null,null);
+
+    verify(session, never()).move(anyString(), anyString());
+
+
+    ValueParam valueParam1 = new ValueParam();
+    valueParam1.setName("origin-folder-path");
+    valueParam1.setValue("/Documents/News");
+    initParams.addParameter(valueParam1);
+    ValueParam valueParam2 = new ValueParam();
+    valueParam2.setName("destination-folder-path");
+    valueParam2.setValue("/");
+    initParams.addParameter(valueParam2);
+    Space space1 = new Space();
+    space1.setGroupId("/spaces/spaceOne");
+
+    Space space2 = new Space();
+    space2.setGroupId("/spaces/spaceTw");
+
+    ListAccess<Space> spaces = mock(SpaceListAccess.class);
+    when(spaces.load(anyInt(), anyInt())).thenReturn(new Space[]{space1, space2});
+
+    when(spaceService.getAllSpacesWithListAccess()).thenReturn(spaces);
+
+    plugin = new MoveNodesUpgradePlugin(initParams,
+            spaceService,
+            repositoryService,
+            sessionProviderService);
+    plugin.processUpgrade(null,null);
+
+    verify(session, times(2)).move(anyString(), anyString());
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -33,6 +33,7 @@
     <module>data-upgrade-processes-permissions</module>
     <module>data-upgrade-es-reindex</module>
     <module>data-upgrade-packaging</module>
+    <module>data-upgrade-move-folders</module>
   </modules>
   <properties>
     <!-- 3rd party libraries versions -->


### PR DESCRIPTION
This upgrade plugion will move the images folders of :
 - Notes : from SPACE_ROOT/Documents/notes/images to SPACE_ROOT/notes/images
 - News : from SPACE_ROOT/Documents/news/images to SPACE_ROOT/News/images
 
It could be reused for similar cases , we have just to give a new name to the plugin and define the source path and the target path with a list of folders to remove if needed