### PR TITLE
fix: Add UpgradePlugin to reload a page configuration property - EXO-67772

### DIFF
--- a/data-upgrade-pages/src/main/java/org/exoplatform/migration/PagePropertyMigration.java
+++ b/data-upgrade-pages/src/main/java/org/exoplatform/migration/PagePropertyMigration.java
@@ -1,0 +1,107 @@
+package org.exoplatform.migration;
+
+import org.exoplatform.commons.persistence.impl.EntityManagerService;
+import org.exoplatform.commons.upgrade.UpgradePluginExecutionContext;
+import org.exoplatform.commons.upgrade.UpgradeProductPlugin;
+import org.exoplatform.container.ExoContainerContext;
+import org.exoplatform.container.PortalContainer;
+import org.exoplatform.container.component.RequestLifeCycle;
+import org.exoplatform.container.xml.InitParams;
+import org.exoplatform.services.log.ExoLogger;
+import org.exoplatform.services.log.Log;
+
+import javax.persistence.EntityManager;
+import javax.persistence.Query;
+
+public class PagePropertyMigration extends UpgradeProductPlugin {
+
+    private static final Log LOG                        = ExoLogger.getExoLogger(PagesMigration.class);
+
+    private static final String  PAGE_NAME    = "page.name";
+    private static final String  PAGE_PROPERTY_NAME    = "page.property.name";
+
+    private static final String  NEW_PAGE_PROPERTY_VALUE = "new.page.property.value";
+
+    private PortalContainer      container;
+
+    private EntityManagerService entityManagerService;
+
+    private String pagePropertyName;
+
+    private String pagePropertyValue;
+
+    private String pageName;
+
+    private int                  pagesUpdatedCount;
+
+
+    public PagePropertyMigration(PortalContainer container,
+                          EntityManagerService entityManagerService,
+                          InitParams initParams) {
+        super(initParams);
+        this.container = container;
+        this.entityManagerService = entityManagerService;
+
+        if (initParams.containsKey(PAGE_NAME)) {
+            this.pageName = initParams.getValueParam(PAGE_NAME).getValue();
+        }
+
+        if (initParams.containsKey(PAGE_PROPERTY_NAME)) {
+             this.pagePropertyName = initParams.getValueParam(PAGE_PROPERTY_NAME).getValue();
+            if (initParams.containsKey(NEW_PAGE_PROPERTY_VALUE)) {
+                this.pagePropertyValue = initParams.getValueParam(NEW_PAGE_PROPERTY_VALUE).getValue();
+            }
+        }
+    }
+
+    @Override
+    public boolean shouldProceedToUpgrade(String newVersion,
+                                          String previousGroupVersion,
+                                          UpgradePluginExecutionContext previousUpgradePluginExecution) {
+
+        int executionCount = previousUpgradePluginExecution == null ? 0 : previousUpgradePluginExecution.getExecutionCount();
+        return !isExecuteOnlyOnce() || executionCount == 0;
+    }
+
+    @Override
+    public void processUpgrade(String oldVersion, String newVersion) {
+        if (pageName == null || pageName.isEmpty() || pagePropertyName == null || pagePropertyName.isEmpty() || pagePropertyValue == null || pagePropertyValue.isEmpty()) {
+            LOG.error("Couldn't process upgrade, the parameter '{}' is mandatory", PAGE_PROPERTY_NAME);
+            return;
+        }
+
+        long startupTime = System.currentTimeMillis();
+
+        ExoContainerContext.setCurrentContainer(container);
+        boolean transactionStarted = false;
+
+        RequestLifeCycle.begin(this.entityManagerService);
+        EntityManager entityManager = this.entityManagerService.getEntityManager();
+        try {
+            if (!entityManager.getTransaction().isActive()) {
+                entityManager.getTransaction().begin();
+                transactionStarted = true;
+            }
+
+            String sqlString = "UPDATE PORTAL_PAGES  SET " + pagePropertyName + " = " + pagePropertyValue
+                    + " WHERE NAME = '" + pageName + "';";
+            Query nativeQuery = entityManager.createNativeQuery(sqlString);
+            this.pagesUpdatedCount = nativeQuery.executeUpdate();
+            LOG.info("End upgrade of '{}' pages with property name '{}' to use '{}' as new value. It took {} ms",
+                    pagesUpdatedCount,
+                    pagePropertyName,
+                    pagePropertyValue,
+                    (System.currentTimeMillis() - startupTime));
+            if (transactionStarted && entityManager.getTransaction().isActive()) {
+                entityManager.getTransaction().commit();
+                entityManager.flush();
+            }
+        } catch (Exception e) {
+            if (transactionStarted && entityManager.getTransaction().isActive() && entityManager.getTransaction().getRollbackOnly()) {
+                entityManager.getTransaction().rollback();
+            }
+        } finally {
+            RequestLifeCycle.end();
+        }
+    }
+}

--- a/data-upgrade-pages/src/main/resources/conf/portal/configuration.xml
+++ b/data-upgrade-pages/src/main/resources/conf/portal/configuration.xml
@@ -638,6 +638,54 @@
         </value-param>
       </init-params>
     </component-plugin>
+    <component-plugin profiles="chat">
+      <name>PagePropertyMigration</name>
+      <set-method>addUpgradePlugin</set-method>
+      <type>org.exoplatform.migration.PagePropertyMigration</type>
+      <description>Replaces the old property value with the new property value</description>
+      <init-params>
+        <value-param>
+          <name>page.name</name>
+          <description>The page name</description>
+          <value>chat</value>
+        </value-param>
+        <value-param>
+          <name>product.group.id</name>
+          <description>The groupId of the product</description>
+          <value>org.exoplatform.platform</value>
+        </value-param>
+        <value-param>
+          <name>page.property.name</name>
+          <description>The page property name</description>
+          <value>HIDE_SHARED_LAYOUT</value>
+        </value-param>
+        <value-param>
+          <name>new.page.property.value</name>
+          <description>The new page property value</description>
+          <value>1</value>
+        </value-param>
+        <value-param>
+          <name>plugin.upgrade.target.version</name>
+          <description>The plugin target version of selected groupId</description>
+          <value>6.6.0</value>
+        </value-param>
+        <value-param>
+          <name>plugin.execution.order</name>
+          <description>The plugin execution order</description>
+          <value>10</value>
+        </value-param>
+        <value-param>
+          <name>plugin.upgrade.execute.once</name>
+          <description>The plugin must be executed only once</description>
+          <value>true</value>
+        </value-param>
+        <value-param>
+          <name>plugin.upgrade.async.execution</name>
+          <description>The plugin will be executed in an asynchronous mode</description>
+          <value>true</value>
+        </value-param>
+      </init-params>
+    </component-plugin>
 
   </external-component-plugins>
 </configuration>


### PR DESCRIPTION
Before this fix, the page chat was modified in configuration du property and we need to reload it. As it is only possible by properties, which not work correctly, we create an UpgradePlugin to do it.