### PR TITLE
fix: Enable the import documents notification plugin by default after migrating to version 6.5 - EXO-68085 (#182)

### DIFF
--- a/data-upgrade-notifications/src/main/java/org/exoplatform/portal/upgrade/notification/ImportDocumentsNotificationUpgradePlugin.java
+++ b/data-upgrade-notifications/src/main/java/org/exoplatform/portal/upgrade/notification/ImportDocumentsNotificationUpgradePlugin.java
@@ -1,0 +1,130 @@
+package org.exoplatform.portal.upgrade.notification;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.exoplatform.commons.api.notification.model.PluginInfo;
+import org.exoplatform.commons.api.notification.model.UserSetting;
+import org.exoplatform.commons.api.notification.service.setting.PluginSettingService;
+import org.exoplatform.commons.api.notification.service.setting.UserSettingService;
+import org.exoplatform.commons.api.settings.SettingService;
+import org.exoplatform.commons.api.settings.data.Context;
+import org.exoplatform.commons.persistence.impl.EntityManagerService;
+import org.exoplatform.commons.upgrade.UpgradePluginExecutionContext;
+import org.exoplatform.commons.upgrade.UpgradeProductPlugin;
+import org.exoplatform.container.ExoContainer;
+import org.exoplatform.container.ExoContainerContext;
+import org.exoplatform.container.xml.InitParams;
+import org.exoplatform.services.log.ExoLogger;
+import org.exoplatform.services.log.Log;
+
+public class ImportDocumentsNotificationUpgradePlugin extends UpgradeProductPlugin {
+
+  private static final Log           LOG                 = ExoLogger.getLogger(ImportDocumentsNotificationUpgradePlugin.class);
+
+  private static final String        NOTIFICATION_PLUGIN = "notification.plugin.type";
+
+  private final SettingService       settingService;
+
+  private final UserSettingService   userSettingService;
+
+  private final PluginSettingService pluginSettingService;
+
+  private final EntityManagerService entityManagerService;
+
+  private String                     notificationPlugin;
+
+  public ImportDocumentsNotificationUpgradePlugin(SettingService settingService,
+                                                  UserSettingService userSettingService,
+                                                  PluginSettingService pluginSettingService,
+                                                  EntityManagerService entityManagerService,
+                                                  InitParams initParams) {
+    super(settingService, initParams);
+    this.settingService = settingService;
+    this.userSettingService = userSettingService;
+    this.pluginSettingService = pluginSettingService;
+    this.entityManagerService = entityManagerService;
+    if (initParams.containsKey(NOTIFICATION_PLUGIN)) {
+      notificationPlugin = initParams.getValueParam(NOTIFICATION_PLUGIN).getValue();
+    }
+  }
+
+  @Override
+  public boolean shouldProceedToUpgrade(String newVersion,
+                                        String previousGroupVersion,
+                                        UpgradePluginExecutionContext previousUpgradePluginExecution) {
+    int executionCount = previousUpgradePluginExecution == null ? 0 : previousUpgradePluginExecution.getExecutionCount();
+    return !isExecuteOnlyOnce() || executionCount == 0;
+  }
+
+  @Override
+  public void processUpgrade(String s, String s1) {
+    if (notificationPlugin == null || notificationPlugin.isEmpty()) {
+      LOG.error("Couldn't process upgrade, the parameter '{}' is mandatory", NOTIFICATION_PLUGIN);
+      return;
+    }
+    ExoContainer currentContainer = ExoContainerContext.getCurrentContainer();
+    int pageSize = 20;
+    int current = 0;
+    try {
+      LOG.info("=== Start initialisation of {} settings", notificationPlugin);
+      LOG.info("  Starting activating {} Notifications for users", notificationPlugin);
+
+      Optional<PluginInfo> optionalPluginTypeConfig =
+                                                    pluginSettingService.getAllPlugins()
+                                                                        .stream()
+                                                                        .filter(pluginInfo -> pluginInfo.getType().equals(notificationPlugin))
+                                                                        .findFirst();
+      PluginInfo pluginTypeConfig;
+      if (optionalPluginTypeConfig.isPresent()) {
+        pluginTypeConfig = optionalPluginTypeConfig.get();
+      } else {
+        LOG.error("Couldn't process upgrade, the '{}' plugin is missing or not found", notificationPlugin);
+        return;
+      }
+      List<String> usersContexts;
+      entityManagerService.startRequest(currentContainer);
+      long startTime = System.currentTimeMillis();
+      do {
+        LOG.info("  Progression of users {} Notifications settings initialisation : {} users", notificationPlugin, current);
+        // Get all users who already update their notification settings
+        usersContexts = settingService.getContextNamesByType(Context.USER.getName(), current, pageSize);
+        if (usersContexts != null) {
+          for (String userName : usersContexts) {
+            try {
+              entityManagerService.endRequest(currentContainer);
+              entityManagerService.startRequest(currentContainer);
+              UserSetting userSetting = this.userSettingService.get(userName);
+              if (userSetting != null) {
+                updateSetting(userSetting, pluginTypeConfig);
+                userSettingService.save(userSetting);
+              }
+            } catch (Exception e) {
+              LOG.error("  Error while activating {} Notifications for user {} ", notificationPlugin, userName, e);
+            }
+          }
+          current += usersContexts.size();
+        }
+      } while (usersContexts != null && !usersContexts.isEmpty());
+      long endTime = System.currentTimeMillis();
+      LOG.info("  Users {} Notifications settings initialised in {} ms", notificationPlugin, (endTime - startTime));
+    } catch (Exception e) {
+      LOG.error("Error while initialisation of users {} Notifications settings - Cause :", notificationPlugin, e.getMessage(), e);
+    } finally {
+      entityManagerService.endRequest(currentContainer);
+    }
+    LOG.info("=== {} users with modified notifications settings have been found and processed successfully", current);
+    LOG.info("=== End initialisation of {} Notifications settings", notificationPlugin);
+  }
+  private void updateSetting(UserSetting userSetting, PluginInfo config) {
+    for (String defaultConf : config.getDefaultConfig()) {
+      for (String channelId : userSetting.getChannelActives()) {
+        if (UserSetting.FREQUENCY.getFrequecy(defaultConf) == UserSetting.FREQUENCY.INSTANTLY) {
+          userSetting.addChannelPlugin(channelId, config.getType());
+        } else {
+          userSetting.addPlugin(config.getType(), UserSetting.FREQUENCY.getFrequecy(defaultConf));
+        }
+      }
+    }
+  }
+}

--- a/data-upgrade-notifications/src/main/resources/conf/portal/configuration.xml
+++ b/data-upgrade-notifications/src/main/resources/conf/portal/configuration.xml
@@ -65,6 +65,45 @@
         </value-param>
       </init-params>
     </component-plugin>
+
+    <component-plugin>
+      <name>ImportDocumentsNotificationUpgradePlugin</name>
+      <set-method>addUpgradePlugin</set-method>
+      <type>org.exoplatform.portal.upgrade.notification.ImportDocumentsNotificationUpgradePlugin</type>
+      <description>Import Documents Notification Upgrade Plugin</description>
+      <init-params>
+        <value-param>
+          <name>product.group.id</name>
+          <description>The groupId of the product</description>
+          <value>org.exoplatform.platform</value>
+        </value-param>
+        <value-param>
+          <name>plugin.execution.order</name>
+          <description>The plugin execution order</description>
+          <value>1</value>
+        </value-param>
+        <value-param>
+          <name>plugin.upgrade.execute.once</name>
+          <description>Execute this upgrade plugin only once</description>
+          <value>true</value>
+        </value-param>
+        <value-param>
+          <name>plugin.upgrade.target.version</name>
+          <description>Target version of the plugin</description>
+          <value>6.6.0</value>
+        </value-param>
+        <value-param>
+          <name>plugin.upgrade.async.execution</name>
+          <description>Execute this upgrade asynchronously</description>
+          <value>true</value>
+        </value-param>
+        <value-param>
+          <name>notification.plugin.type</name>
+          <description>the notification plugin type</description>
+          <value>ImportDocumentsPlugin</value>
+        </value-param>
+      </init-params>
+    </component-plugin>
   </external-component-plugins>
 </configuration>
 

--- a/data-upgrade-notifications/src/test/java/org/exoplatform/portal/upgrade/notification/ImportDocumentsNotificationUpgradePluginTest.java
+++ b/data-upgrade-notifications/src/test/java/org/exoplatform/portal/upgrade/notification/ImportDocumentsNotificationUpgradePluginTest.java
@@ -1,0 +1,85 @@
+package org.exoplatform.portal.upgrade.notification;
+
+import static org.mockito.Mockito.*;
+
+import java.util.*;
+
+import org.junit.AfterClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import org.exoplatform.commons.api.notification.model.PluginInfo;
+import org.exoplatform.commons.api.notification.model.UserSetting;
+import org.exoplatform.commons.api.notification.service.setting.PluginSettingService;
+import org.exoplatform.commons.api.notification.service.setting.UserSettingService;
+import org.exoplatform.commons.api.settings.SettingService;
+import org.exoplatform.commons.api.settings.data.Context;
+import org.exoplatform.commons.persistence.impl.EntityManagerService;
+import org.exoplatform.container.ExoContainerContext;
+import org.exoplatform.container.PortalContainer;
+import org.exoplatform.container.xml.InitParams;
+import org.exoplatform.container.xml.ValueParam;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ImportDocumentsNotificationUpgradePluginTest {
+
+  private static final MockedStatic<ExoContainerContext> EXO_CONTAINER_CONTEXT = mockStatic(ExoContainerContext.class);
+
+  private static final MockedStatic<PortalContainer>     PORTAL_CONTAINER      = mockStatic(PortalContainer.class);
+
+  @Mock
+  private EntityManagerService                           entityManagerService;
+
+  @Mock
+  private SettingService                                 settingService;
+
+  @Mock
+  private UserSettingService                             userSettingService;
+
+  @Mock
+  private PluginSettingService                           pluginSettingService;
+
+  @AfterClass
+  public static void afterRunBare() throws Exception { // NOSONAR
+    EXO_CONTAINER_CONTEXT.close();
+    PORTAL_CONTAINER.close();
+  }
+
+  @Test
+  public void processUpgrade() throws Exception {
+    InitParams initParams = new InitParams();
+    ValueParam valueParam = new ValueParam();
+    valueParam.setName("product.group.id");
+    valueParam.setValue("org.exoplatform.platform");
+    initParams.addParameter(valueParam);
+    valueParam.setName("notification.plugin.type");
+    valueParam.setValue("ImportDocumentsPlugin");
+    initParams.addParam(valueParam);
+    PortalContainer container = mock(PortalContainer.class);
+    EXO_CONTAINER_CONTEXT.when(() -> ExoContainerContext.getCurrentContainer()).thenReturn(container);
+    PluginInfo pluginTypeConfig = mock(PluginInfo.class);
+    when(pluginSettingService.getAllPlugins()).thenReturn(Collections.singletonList(pluginTypeConfig));
+    when(settingService.getContextNamesByType(Context.USER.getName(), 0, 20)).thenReturn(List.of("userTest"));
+    UserSetting userSetting = mock(UserSetting.class);
+    Set<String> channelActives = new HashSet<>();
+    channelActives.add("MAIL_CHANNEL");
+    when(userSetting.getChannelActives()).thenReturn(channelActives);
+    when(userSettingService.get("userTest")).thenReturn(userSetting);
+    when(pluginTypeConfig.getDefaultConfig()).thenReturn(Arrays.asList("daily", "Instantly"));
+    when(pluginTypeConfig.getType()).thenReturn("ImportDocumentsPlugin");
+    ImportDocumentsNotificationUpgradePlugin notificationUpgradePlugin =
+                                                                       new ImportDocumentsNotificationUpgradePlugin(settingService,
+                                                                                                                    userSettingService,
+                                                                                                                    pluginSettingService,
+                                                                                                                    entityManagerService,
+                                                                                                                    initParams);
+    notificationUpgradePlugin.processUpgrade(null, null);
+    //
+    verify(userSetting, times(1)).addChannelPlugin("MAIL_CHANNEL", pluginTypeConfig.getType());
+    verify(userSetting, times(1)).addPlugin(pluginTypeConfig.getType(), UserSetting.FREQUENCY.getFrequecy("daily"));
+    verify(userSettingService, times(1)).save(userSetting);
+  }
+}


### PR DESCRIPTION

Prior to this change, after upgrading from version 6.4 to version 6.5, the import documents notification was disabled by default. This upgrade will enable the import documents notification by default after migrating to version 6.5.