### PR TITLE
fix: Fix the upgrade plugin error when starting new server -EXO-68823…

### DIFF
--- a/data-upgrade-notifications/src/main/java/org/exoplatform/portal/upgrade/notification/NotificationSettingsUpgradePlugin.java
+++ b/data-upgrade-notifications/src/main/java/org/exoplatform/portal/upgrade/notification/NotificationSettingsUpgradePlugin.java
@@ -61,7 +61,10 @@ public class NotificationSettingsUpgradePlugin extends UpgradeProductPlugin {
 
         PluginInfo pluginTypeConfig = findPlugin(pluginType);
         List<String> usersContexts;
-
+        if (pluginTypeConfig == null) {
+          LOG.info("=== couldn't initialize the settings of {} , plugin is not found", pluginType);
+          continue;
+        }
         entityManagerService.startRequest(currentContainer);
         long startTime = System.currentTimeMillis();
         do {


### PR DESCRIPTION


Prior to this change, a null pointer exception was thrown from the notification upgrade plugin when starting a new server. This issue is due to the null value of the pluginInfo model if the plugin is missing. This change is going to handle this exception