### PR TITLE
fix: Enable NodeTypeTemplateUpgradePlugin for 6.6.0 version in order to upgrade exo:news jcr nodetype view template - EXO-69032

### DIFF
--- a/data-upgrade-ecms/src/main/resources/conf/portal/configuration.xml
+++ b/data-upgrade-ecms/src/main/resources/conf/portal/configuration.xml
@@ -82,42 +82,7 @@
         </value-param>
       </init-params>
     </component-plugin>
-
-
-    <component-plugin>
-      <name>NodeTypeTemplateUpgradePlugin</name>
-      <set-method>addUpgradePlugin</set-method>
-      <type>org.exoplatform.ecms.upgrade.templates.NodeTypeTemplateUpgradePlugin</type>
-      <description>Upgrade templates for node types</description>
-      <init-params>
-        <value-param>
-          <name>product.group.id</name>
-          <description>The groupId of the product</description>
-          <value>org.exoplatform.ecms</value>
-        </value-param>
-        <value-param>
-          <name>plugin.execution.order</name>
-          <description>The plugin execution order</description>
-          <value>2</value>
-        </value-param>
-        <value-param>
-          <name>plugin.upgrade.execute.once</name>
-          <description>Execute this upgrade plugin only once</description>
-          <value>false</value>
-        </value-param>
-        <value-param>
-          <name>plugin.upgrade.async.execution</name>
-          <description>Execute this upgrade asynchronously</description>
-          <value>true</value>
-        </value-param>
-        <value-param>
-          <name>plugin.upgrade.target.version</name>
-          <description>Target version of the plugin</description>
-          <value>6.3.0</value>
-        </value-param>
-      </init-params>
-    </component-plugin>
-
+	
     <component-plugin>
       <name>upgradeTemplateParamsPlugin</name>
       <set-method>addUpgradePlugin</set-method>
@@ -158,6 +123,40 @@
           <name>plugin.upgrade.target.version</name>
           <description>Target version of the plugin</description>
           <value>6.5.0</value>
+        </value-param>
+      </init-params>
+    </component-plugin>
+	
+    <component-plugin>
+      <name>NodeTypeTemplateUpgradePlugin</name>
+      <set-method>addUpgradePlugin</set-method>
+      <type>org.exoplatform.ecms.upgrade.templates.NodeTypeTemplateUpgradePlugin</type>
+      <description>Upgrade templates for node types</description>
+      <init-params>
+        <value-param>
+          <name>product.group.id</name>
+          <description>The groupId of the product</description>
+          <value>org.exoplatform.ecms</value>
+        </value-param>
+        <value-param>
+          <name>plugin.execution.order</name>
+          <description>The plugin execution order</description>
+          <value>2</value>
+        </value-param>
+        <value-param>
+          <name>plugin.upgrade.execute.once</name>
+          <description>Execute this upgrade plugin only once</description>
+          <value>false</value>
+        </value-param>
+        <value-param>
+          <name>plugin.upgrade.async.execution</name>
+          <description>Execute this upgrade asynchronously</description>
+          <value>true</value>
+        </value-param>
+        <value-param>
+          <name>plugin.upgrade.target.version</name>
+          <description>Target version of the plugin</description>
+          <value>6.6.0</value>
         </value-param>
       </init-params>
     </component-plugin>


### PR DESCRIPTION

The bad display problem of news article jcr node from file explorer is fixed by modifying the exo:news jcr nodetype view template, for existing data instances, we need to enable the NodeTypeTemplateUpgradePlugin for next version in order to apply the exo:news jcr nodetype view template modification.