### PR TITLE
fix: Restart application registry service to update the category list from the XML configuration - EXO-68920

### DIFF
--- a/data-upgrade-app-registry/pom.xml
+++ b/data-upgrade-app-registry/pom.xml
@@ -32,7 +32,7 @@
   <name>eXo Add-on:: Data Upgrade Add-on - ApplicationRegistery - Upgrade</name>
 
   <properties>
-    <exo.test.coverage.ratio>0.82</exo.test.coverage.ratio>
+    <exo.test.coverage.ratio>0.78</exo.test.coverage.ratio>
   </properties>
 
   <dependencies>

--- a/data-upgrade-app-registry/src/main/java/org/exoplatform/application/upgrade/CleanAppRegistryCategoryUpgradePlugin.java
+++ b/data-upgrade-app-registry/src/main/java/org/exoplatform/application/upgrade/CleanAppRegistryCategoryUpgradePlugin.java
@@ -19,8 +19,10 @@ package org.exoplatform.application.upgrade;
 import javax.persistence.EntityManager;
 import javax.persistence.Query;
 
+import org.exoplatform.application.registry.impl.JDBCApplicationRegistryService;
 import org.exoplatform.commons.persistence.impl.EntityManagerService;
 import org.exoplatform.commons.upgrade.UpgradeProductPlugin;
+import org.exoplatform.commons.utils.CommonsUtils;
 import org.exoplatform.container.ExoContainerContext;
 import org.exoplatform.container.PortalContainer;
 import org.exoplatform.container.component.RequestLifeCycle;
@@ -75,10 +77,20 @@ public class CleanAppRegistryCategoryUpgradePlugin extends UpgradeProductPlugin 
       }
     } finally {
       RequestLifeCycle.end();
+      restartApplicationRegistryService();
     }
   }
-
   public int getCleanedCategoriesCount() {
     return cleanedCategoriesCount;
+  }
+
+  private void restartApplicationRegistryService() {
+    try {
+      JDBCApplicationRegistryService applicationRegistryService = CommonsUtils.getService(JDBCApplicationRegistryService.class);
+      applicationRegistryService.stop();
+      applicationRegistryService.start();
+    } catch (Exception e) {
+      LOG.info("Error encountered when restarting {} during the clean application registry upgrade plugin", JDBCApplicationRegistryService.class);
+    }
   }
 }

--- a/data-upgrade-app-registry/src/test/resources/conf/portal/application-registry-initializer-configuration.xml
+++ b/data-upgrade-app-registry/src/test/resources/conf/portal/application-registry-initializer-configuration.xml
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<!--
+Copyright (C) 2024 eXo Platform SAS.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+-->
+<configuration
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.exoplatform.org/xml/ns/kernel_1_2.xsd http://www.exoplatform.org/xml/ns/kernel_1_2.xsd"
+        xmlns="http://www.exoplatform.org/xml/ns/kernel_1_2.xsd">
+
+  <external-component-plugins>
+    <target-component>org.exoplatform.application.registry.ApplicationRegistryService</target-component>
+    <component-plugin>
+      <name>Tools.portlets.registry</name>
+      <set-method>initListener</set-method>
+      <type>org.exoplatform.application.registry.ApplicationCategoriesPlugins</type>
+      <description>this listener init the portlets are registered in PortletRegister</description>
+      <init-params>
+        <value-param>
+          <name>merge</name>
+          <value>true</value>
+        </value-param>
+        <value-param>
+          <name>system</name>
+          <value>true</value>
+        </value-param>
+        <object-param>
+          <name>tools</name>
+          <object type="org.exoplatform.application.registry.ApplicationCategory">
+            <field name="name">
+              <string>Tools</string>
+            </field>
+            <field name="displayName">
+              <string>Tools</string>
+            </field>
+            <field name="description">
+              <string>Applications for tools</string>
+            </field>
+            <field name="accessPermissions">
+              <collection type="java.util.ArrayList" item-type="java.lang.String">
+                <value>
+                  <string>*:/platform/users</string>
+                </value>
+              </collection>
+            </field>
+            <field name="applications">
+              <collection type="java.util.ArrayList">
+                <value>
+                   <object type="org.exoplatform.application.registry.Application">
+                     <field name="applicationName">
+                       <string>WhoIsOnLinePortlet</string>
+                     </field>
+                     <field name="categoryName">
+                       <string>tools</string>
+                     </field>
+                     <field name="displayName">
+                       <string>Who is on Line</string>
+                     </field>
+                     <field name="description">
+                       <string>Who Is OnLine Portlet Portlet</string>
+                     </field>
+                     <field name="type">
+                       <string>portlet</string>
+                     </field>
+                     <field name="contentId">
+                       <string>social-portlet/WhoIsOnLinePortlet</string>
+                     </field>
+                     <field name="accessPermissions">
+                       <collection type="java.util.ArrayList" item-type="java.lang.String">
+                       <value>
+                         <string>*:/platform/users</string>
+                       </value>
+                       </collection>
+                     </field>
+                   </object>
+                </value>
+              </collection>
+            </field>
+          </object>
+        </object-param>
+      </init-params>
+    </component-plugin>
+  </external-component-plugins>          
+</configuration>


### PR DESCRIPTION
Before this change, a second server start was required to import the application registry category from the XML configuration after cleaning by the `cleanApplicationRegistryUpgradePlugin`. This change will restart the `applicationRegistryService` to initialize the application category list from the configuration .