### PR TITLE
fix: Prevent external users from receiving notifications of published news from a space which they are not members - EXO-69079

### DIFF
--- a/data-upgrade-users/src/main/java/org/exoplatform/migration/UserSetExternalInGateinPortal.java
+++ b/data-upgrade-users/src/main/java/org/exoplatform/migration/UserSetExternalInGateinPortal.java
@@ -16,6 +16,7 @@
  */
 package org.exoplatform.migration;
 
+import org.exoplatform.commons.upgrade.UpgradePluginExecutionContext;
 import org.exoplatform.commons.upgrade.UpgradeProductPlugin;
 import org.exoplatform.commons.utils.ListAccess;
 import org.exoplatform.container.ExoContainerContext;
@@ -29,6 +30,7 @@ import org.exoplatform.services.organization.OrganizationService;
 import org.exoplatform.services.organization.UserProfile;
 
 import java.util.Arrays;
+import java.util.concurrent.atomic.AtomicInteger;
 
 public class UserSetExternalInGateinPortal extends UpgradeProductPlugin {
   private static final Log LOG = ExoLogger.getExoLogger(UserSetExternalInGateinPortal.class);
@@ -38,6 +40,14 @@ public class UserSetExternalInGateinPortal extends UpgradeProductPlugin {
     super(initParams);
     this.organizationService=organizationService;
 
+  }
+  @Override
+  public boolean shouldProceedToUpgrade(String newVersion,
+                                        String previousGroupVersion,
+                                        UpgradePluginExecutionContext previousUpgradePluginExecution) {
+
+    int executionCount = previousUpgradePluginExecution == null ? 0 : previousUpgradePluginExecution.getExecutionCount();
+    return !isExecuteOnlyOnce() || executionCount == 0;
   }
   @Override
   public void processUpgrade(String oldVersion, String newVersion) {
@@ -50,7 +60,8 @@ public class UserSetExternalInGateinPortal extends UpgradeProductPlugin {
       LOG.info("Number of users to update : " + total);
 
       int pageSize = 100;
-      int current=0;
+      int current = 0;
+      AtomicInteger updatedUserProfiles = new AtomicInteger(0);
       while (current<total) {
         RequestLifeCycle.begin(ExoContainerContext.getCurrentContainer());
 
@@ -63,9 +74,16 @@ public class UserSetExternalInGateinPortal extends UpgradeProductPlugin {
             if (profile==null) {
               profile=organizationService.getUserProfileHandler().createUserProfileInstance(username);
             }
-            profile.setAttribute(UserProfile.OTHER_KEYS[2],"true");
-            organizationService.getUserProfileHandler().saveUserProfile(profile,true);
-            LOG.debug("External info added in gatein profile for user {}, {}ms", username, System.currentTimeMillis() - startTimeForUser);
+            // do not update the profiles of users who already have the correct external property value
+            if (profile.getAttribute(UserProfile.OTHER_KEYS[2]) != null && String.valueOf(true).equals(profile.getAttribute(UserProfile.OTHER_KEYS[2]))) {
+              LOG.debug("External info already set in gatein profile for user {}", username);
+            } else {
+              profile.setAttribute(UserProfile.OTHER_KEYS[2],"true");
+              organizationService.getUserProfileHandler().saveUserProfile(profile,true);
+              updatedUserProfiles.getAndIncrement();
+              LOG.debug("External info added in gatein profile for user {}", username);
+              LOG.info("Progession : {} users updated on {} total users", updatedUserProfiles.get(), total);
+            }
           } catch (Exception e) {
             LOG.error("Unable to get profile for user {}",username);
           }

--- a/data-upgrade-users/src/main/resources/conf/portal/configuration.xml
+++ b/data-upgrade-users/src/main/resources/conf/portal/configuration.xml
@@ -74,7 +74,7 @@
           <name>plugin.upgrade.target.version</name>
           <description>The plugin target version (will not be executed if previous version is equal or higher than 6.3.1)
           </description>
-          <value>6.6.x</value>
+          <value>6.5.1</value>
         </value-param>
         <value-param>
           <name>plugin.execution.order</name>

--- a/data-upgrade-users/src/main/resources/conf/portal/configuration.xml
+++ b/data-upgrade-users/src/main/resources/conf/portal/configuration.xml
@@ -60,7 +60,7 @@
   <external-component-plugins>
     <target-component>org.exoplatform.commons.upgrade.UpgradeProductService</target-component>
     <component-plugin>
-      <name>ExternalUserUpgradePlugin</name>
+      <name>ExternalUserUpgradePluginV1</name>
       <set-method>addUpgradePlugin</set-method>
       <type>org.exoplatform.migration.UserSetExternalInGateinPortal</type>
       <description>Add external information in gatein portal profile</description>
@@ -74,7 +74,7 @@
           <name>plugin.upgrade.target.version</name>
           <description>The plugin target version (will not be executed if previous version is equal or higher than 6.3.1)
           </description>
-          <value>6.3.0</value>
+          <value>6.6.x</value>
         </value-param>
         <value-param>
           <name>plugin.execution.order</name>


### PR DESCRIPTION

Prior to this change, external users were receiving notifications of published news from a space in which they were not members. This issue was caused by the absence of external property information in the gatein profile, which was only present in the social profile. After updating the ExternalUersLinstenerImp to set the external status in the gatein profile for the newly created users , this change will re-execute the ExternalUserUpgradePlugin to set the external status in the gatein profile for the previously created users.