### PR TITLE
fix: UP NotificationSettingsUpgradePlugin is not efficient - EXO-69816

### DIFF
--- a/data-upgrade-notifications/src/main/java/org/exoplatform/portal/upgrade/notification/NotificationSettingsUpgradePlugin.java
+++ b/data-upgrade-notifications/src/main/java/org/exoplatform/portal/upgrade/notification/NotificationSettingsUpgradePlugin.java
@@ -51,57 +51,60 @@ public class NotificationSettingsUpgradePlugin extends UpgradeProductPlugin {
   public void processUpgrade(String oldVersion, String newVersion) {
     ExoContainer currentContainer = ExoContainerContext.getCurrentContainer();
     List<String> pluginTypes = Arrays.asList(notificationPluginTypes.replace("\n", "").replaceAll("\\s", "").split(","));
+    int pageSize = 20;
+    int current = 0;
+    try {
+      LOG.info("=== Start initialisation of settings");
+      LOG.info("  Starting activating Notifications for users");
+      entityManagerService.startRequest(currentContainer);
+      long startTime = System.currentTimeMillis();
+      List<String> usersContexts;
+      do {
+        LOG.info("  Progression of users Notifications settings initialisation : {} users", current);
 
-    for (String pluginType : pluginTypes) {
-      int pageSize = 20;
-      int current = 0;
-      try {
-        LOG.info("=== Start initialisation of {} settings", pluginType);
-        LOG.info("  Starting activating {} Notifications for users", pluginType);
+        // Get all users who already update their notification settings
+        usersContexts = settingService.getContextNamesByType(Context.USER.getName(), current, pageSize);
 
-        PluginInfo pluginTypeConfig = findPlugin(pluginType);
-        List<String> usersContexts;
-        if (pluginTypeConfig == null) {
-          LOG.info("=== couldn't initialize the settings of {} , plugin is not found", pluginType);
-          continue;
-        }
-        entityManagerService.startRequest(currentContainer);
-        long startTime = System.currentTimeMillis();
-        do {
-          LOG.info("  Progression of users {} Notifications settings initialisation : {} users", pluginType, current);
+        if (usersContexts != null) {
+          for (String userName : usersContexts) {
+            long startUserTime = System.currentTimeMillis();
+            try {
+              entityManagerService.endRequest(currentContainer);
+              entityManagerService.startRequest(currentContainer);
+              UserSetting userSetting = this.userSettingService.get(userName);
+              if (userSetting != null) {
 
-          // Get all users who already update their notification settings
-          usersContexts = settingService.getContextNamesByType(Context.USER.getName(), current, pageSize);
-
-          if (usersContexts != null) {
-            for (String userName : usersContexts) {
-              try {
-                entityManagerService.endRequest(currentContainer);
-                entityManagerService.startRequest(currentContainer);
-
-                UserSetting userSetting = this.userSettingService.get(userName);
-                if (userSetting != null) {
+                for (String pluginType : pluginTypes) {
+                  PluginInfo pluginTypeConfig = findPlugin(pluginType);
+                  if (pluginTypeConfig == null) {
+                    LOG.info("=== couldn't initialize the settings of {} , plugin is not found", pluginType);
+                    continue;
+                  }
                   updateSetting(userSetting, pluginTypeConfig);
-                  userSettingService.save(userSetting);
                 }
-              } catch (Exception e) {
-                LOG.error("  Error while activating {} Notifications for user {} ", pluginType, userName, e);
-              }
-            }
-            current += usersContexts.size();
-          }
-        } while (usersContexts != null && !usersContexts.isEmpty());
-        long endTime = System.currentTimeMillis();
-        LOG.info("  Users {} Notifications settings initialised in {} ms", pluginType, (endTime - startTime));
-      } catch (Exception e) {
-        LOG.error("Error while initialisation of users {} Notifications settings - Cause :", pluginType, e.getMessage(), e);
-      } finally {
-        entityManagerService.endRequest(currentContainer);
-      }
 
-      LOG.info("=== {} users with modified notifications settings have been found and processed successfully", current);
-      LOG.info("=== End initialisation of {} Notifications settings", pluginType);
+                userSettingService.save(userSetting);
+              }
+            } catch (Exception e) {
+              LOG.error("Error while activating {} Notifications for user {} ", userName, e);
+            }
+            LOG.info("Time to treat user={} : {}ms", userName, System.currentTimeMillis() - startUserTime);
+          }
+          current += usersContexts.size();
+        }
+      } while (usersContexts != null && !usersContexts.isEmpty());
+      long endTime = System.currentTimeMillis();
+      LOG.info("  Users Notifications settings initialised in {} ms", (endTime - startTime));
+    } catch (Exception e) {
+      LOG.error("Error while initialisation of users Notifications settings - Cause :", e.getMessage(), e);
+    } finally {
+      entityManagerService.endRequest(currentContainer);
     }
+
+    LOG.info("=== {} users with modified notifications settings have been found and processed successfully", current);
+    LOG.info("=== End initialisation of Notifications settings");
+
+
   }
 
   private PluginInfo findPlugin(String type) {


### PR DESCRIPTION
Before this fix, the number of database queries for this up is proportional to the number of plugin, multiplied by the number of users. As we have more than 30 notifications plugin, the number of database queries is huge This commit change the way settings are updated by firstly searching users, instead of firstly browsing plugin. In this way, the queries number is not more proportionnal to plugin number, only to user number