### PR TITLE
fix: Configure the PortalNavigationIconUpgradePlugin to set icons to the portal navigation nodes - EXO-69848

### DIFF
--- a/data-upgrade-navigations/src/main/java/org/exoplatform/migration/PortalNavigationIconMigration.java
+++ b/data-upgrade-navigations/src/main/java/org/exoplatform/migration/PortalNavigationIconMigration.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright (C) 2003-2024 eXo Platform SAS
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <gnu.org/licenses>.
+ */
+package org.exoplatform.migration;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.exoplatform.commons.api.persistence.ExoTransactional;
+import org.exoplatform.commons.persistence.impl.EntityManagerService;
+import org.exoplatform.commons.upgrade.UpgradeProductPlugin;
+import org.exoplatform.container.xml.InitParams;
+import org.exoplatform.services.log.ExoLogger;
+import org.exoplatform.services.log.Log;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.Query;
+
+/**
+ * This plugin will be executed in order to set icons for the portal navigation
+ * nodes as provided in the configuration
+ */
+public class PortalNavigationIconMigration extends UpgradeProductPlugin {
+
+  private static final Log           LOG                  = ExoLogger.getExoLogger(PortalNavigationIconMigration.class);
+
+  private static final String        ICON_UPDATE_SQL      =
+                                                     """
+                                                           UPDATE PORTAL_NAVIGATION_NODES
+                                                           SET ICON =
+                                                             CASE
+                                                               %s
+                                                             END
+                                                           WHERE ICON IS NULL
+                                                           AND EXISTS (SELECT * FROM PORTAL_PAGES p INNER JOIN PORTAL_SITES s ON s.ID = p.SITE_ID WHERE PAGE_ID = p.ID AND s.TYPE = 0 AND s.NAME LIKE 'dw')
+                                                         """;
+
+  private static final String        ICON_UPDATE_CASE_SQL = """
+         WHEN NAME in (%s) THEN TRIM('%s')
+      """;
+
+  private static final String        PORTAL_NODE_NAMES    = "portal.node.names";
+
+  private static final String        PORTAL_NODE_ICONS    = "portal.node.icons";
+
+  private final EntityManagerService entityManagerService;
+
+  private final Map<String, String>  portalNodes          = new HashMap<>();
+
+  private int                        migratedPortalNodeIcons;
+
+  public PortalNavigationIconMigration(EntityManagerService entityManagerService, InitParams initParams) {
+    super(initParams);
+    this.entityManagerService = entityManagerService;
+    if (initParams.containsKey(PORTAL_NODE_ICONS) && initParams.containsKey(PORTAL_NODE_NAMES)) {
+      String[] portalNodeNames = initParams.getValueParam(PORTAL_NODE_NAMES).getValue().split(";");
+      String[] portalNodeIcons = initParams.getValueParam(PORTAL_NODE_ICONS).getValue().split(";");
+      if (portalNodeIcons.length == portalNodeNames.length) {
+        for (int i = 0; i < portalNodeNames.length; i++) {
+          this.portalNodes.put(portalNodeNames[i], portalNodeIcons[i]);
+        }
+      }
+    }
+  }
+
+  @Override
+  public boolean shouldProceedToUpgrade(String newVersion, String previousVersion) {
+    return !portalNodes.isEmpty();
+  }
+
+  @Override
+  public void processUpgrade(String oldVersion, String newVersion) {
+
+    long startupTime = System.currentTimeMillis();
+
+    LOG.info("Start:: Upgrade of portal navigation node icons");
+    Set<Map.Entry<String, String>> portalNodesEntrySet = portalNodes.entrySet();
+    this.migratedPortalNodeIcons = upgradePortalNodeIcons(portalNodesEntrySet);
+    LOG.info("End:: Upgrade of '{}' node icons. It tooks {} ms",
+             migratedPortalNodeIcons,
+             (System.currentTimeMillis() - startupTime));
+  }
+
+  @ExoTransactional
+  public int upgradePortalNodeIcons(Set<Map.Entry<String, String>> portalNodesEntrySet) {
+    EntityManager entityManager = entityManagerService.getEntityManager();
+
+    String sqlStatement = String.format(ICON_UPDATE_SQL, portalNodes.entrySet().stream().map(e -> {
+      String keys = Arrays.stream(e.getKey().split(",")).map(key -> String.format("'%s'", key)).collect(Collectors.joining(","));
+      return String.format(ICON_UPDATE_CASE_SQL, keys, e.getValue());
+    }).collect(Collectors.joining()));
+    Query query = entityManager.createNativeQuery(sqlStatement);
+    return query.executeUpdate();
+  }
+
+  public int getMigratedPortalNodeIconsNodeIcons() {
+    return migratedPortalNodeIcons;
+  }
+}

--- a/data-upgrade-navigations/src/main/java/org/exoplatform/migration/PortalNavigationIconMigration.java
+++ b/data-upgrade-navigations/src/main/java/org/exoplatform/migration/PortalNavigationIconMigration.java
@@ -1,7 +1,7 @@
 /*
- * Copyright (C) 2003-2024 eXo Platform SAS
+ * Copyright (C) 2024 eXo Platform SAS.
  *
- *  This program is free software: you can redistribute it and/or modify
+ * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
@@ -9,10 +9,10 @@
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
+ * GNU Affero General Public License for more details.
  *
  * You should have received a copy of the GNU Affero General Public License
- * along with this program.  If not, see <gnu.org/licenses>.
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 package org.exoplatform.migration;
 

--- a/data-upgrade-navigations/src/main/resources/conf/portal/configuration.xml
+++ b/data-upgrade-navigations/src/main/resources/conf/portal/configuration.xml
@@ -195,5 +195,48 @@
         </value-param>
       </init-params>
     </component-plugin>
+    <component-plugin>
+      <name>PortalNavigationIconUpgradePlugin</name>
+      <set-method>addUpgradePlugin</set-method>
+      <type>org.exoplatform.migration.PortalNavigationIconMigration</type>
+      <description>Configure portal node icons</description>
+      <init-params>
+        <value-param>
+          <name>product.group.id</name>
+          <description>The groupId of the product</description>
+          <value>org.exoplatform.platform</value>
+        </value-param>
+        <value-param>
+          <name>plugin.upgrade.target.version</name>
+          <description>The plugin target version (will not be executed if previous version is equal or higher than 6.6.0)</description>
+          <value>6.6.0</value>
+        </value-param>
+        <value-param>
+          <name>portal.node.names</name>
+          <description>The plugin will set the icons of these portal nodes names</description>
+          <value>external-stream</value>
+        </value-param>
+        <value-param>
+          <name>portal.node.icons</name>
+          <description>The plugin will set the portal nodes icons with these icons</description>
+          <value>fas fa-user-lock</value>
+        </value-param>
+        <value-param>
+          <name>plugin.execution.order</name>
+          <description>The plugin execution order</description>
+          <value>101</value>
+        </value-param>
+        <value-param>
+          <name>plugin.upgrade.execute.once</name>
+          <description>The plugin must be executed only once</description>
+          <value>true</value>
+        </value-param>
+        <value-param>
+          <name>plugin.upgrade.async.execution</name>
+          <description>The plugin will be executed in an asynchronous mode</description>
+          <value>true</value>
+        </value-param>
+      </init-params>
+    </component-plugin>
   </external-component-plugins>
 </configuration>

--- a/data-upgrade-navigations/src/test/java/org/exoplatform/migration/PortalNavigationIconMigrationTest.java
+++ b/data-upgrade-navigations/src/test/java/org/exoplatform/migration/PortalNavigationIconMigrationTest.java
@@ -1,0 +1,103 @@
+package org.exoplatform.migration;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import org.exoplatform.commons.persistence.impl.EntityManagerService;
+import org.exoplatform.component.test.AbstractKernelTest;
+import org.exoplatform.component.test.ConfigurationUnit;
+import org.exoplatform.component.test.ConfiguredBy;
+import org.exoplatform.component.test.ContainerScope;
+import org.exoplatform.container.PortalContainer;
+import org.exoplatform.container.component.RequestLifeCycle;
+import org.exoplatform.container.xml.InitParams;
+import org.exoplatform.container.xml.ValueParam;
+import org.exoplatform.portal.jdbc.entity.NodeEntity;
+import org.exoplatform.portal.jdbc.entity.PageEntity;
+import org.exoplatform.portal.jdbc.entity.SiteEntity;
+import org.exoplatform.portal.mop.NodeTarget;
+import org.exoplatform.portal.mop.PageType;
+import org.exoplatform.portal.mop.SiteType;
+import org.exoplatform.portal.mop.dao.NodeDAO;
+import org.exoplatform.portal.mop.dao.PageDAO;
+import org.exoplatform.portal.mop.dao.SiteDAO;
+
+@ConfiguredBy({ @ConfigurationUnit(scope = ContainerScope.PORTAL, path = "conf/portal/configuration.xml"),
+    @ConfigurationUnit(scope = ContainerScope.PORTAL, path = "conf/exo.portal.component.portal-configuration-local.xml"),
+    @ConfigurationUnit(scope = ContainerScope.PORTAL, path = "org/exoplatform/portal/config/conf/configuration.xml") })
+public class PortalNavigationIconMigrationTest extends AbstractKernelTest {
+  InitParams                            initParams = new InitParams();
+  private PortalContainer               container;
+  private EntityManagerService          entityManagerService;
+  private PortalNavigationIconMigration portalNavigationIconMigration;
+  private SiteDAO                       siteDAO;
+  private PageDAO                       pageDAO;
+  private NodeDAO                       nodeDAO;
+
+  @Before
+  public void setUp() {
+    container = getContainer();
+    siteDAO = container.getComponentInstanceOfType(SiteDAO.class);
+    pageDAO = container.getComponentInstanceOfType(PageDAO.class);
+    nodeDAO = container.getComponentInstanceOfType(NodeDAO.class);
+    entityManagerService = container.getComponentInstanceOfType(EntityManagerService.class);
+    begin();
+    ValueParam productGroupIdValueParam = new ValueParam();
+    productGroupIdValueParam.setName("product.group.id");
+    productGroupIdValueParam.setValue("org.exoplatform.platform");
+    ValueParam portalNodeNamesValueParam = new ValueParam();
+    portalNodeNamesValueParam.setName("portal.node.names");
+    portalNodeNamesValueParam.setValue("external-stream");
+    ValueParam portalNodeIconsValueParam = new ValueParam();
+    portalNodeIconsValueParam.setName("portal.node.icons");
+    portalNodeIconsValueParam.setValue("fas fa-user-lock");
+    initParams.addParameter(productGroupIdValueParam);
+    initParams.addParameter(portalNodeNamesValueParam);
+    initParams.addParameter(portalNodeIconsValueParam);
+    this.portalNavigationIconMigration = new PortalNavigationIconMigration(entityManagerService, initParams);
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    end();
+  }
+
+  @Test
+  public void testPortalNavigationIconMigration() {
+
+    SiteEntity siteEntity = new SiteEntity();
+    siteEntity.setName("dw");
+    siteEntity.setSiteType(SiteType.PORTAL);
+    siteDAO.create(siteEntity);
+    siteEntity = siteDAO.findByType(SiteType.PORTAL).stream().filter(e -> e.getName().equals("dw")).toList().get(0);
+    //
+    assertNotNull(siteEntity);
+    PageEntity pageEntity = new PageEntity();
+    pageEntity.setName("stream");
+    pageEntity.setOwner(siteEntity);
+    pageEntity.setPageType(PageType.PAGE);
+    pageDAO.create(pageEntity);
+    pageEntity = pageDAO.findAll().stream().filter(e -> e.getName().equals("stream")).toList().get(0);
+    //
+    assertNotNull(pageEntity);
+    NodeEntity nodeEntity = new NodeEntity();
+    nodeEntity.setName("external-stream");
+    nodeEntity.setIcon(null);
+    nodeEntity.setPage(pageEntity);
+    nodeEntity.setTarget(NodeTarget.NEW_TAB);
+    nodeDAO.create(nodeEntity);
+    nodeEntity = nodeDAO.findAllByPage(pageEntity.getId()).stream().filter(e -> e.getName().equals("external-stream")).toList().get(0);
+    //
+    assertNotNull(nodeEntity);
+    restartTransaction();
+    portalNavigationIconMigration.processUpgrade(null, null);
+    //
+    assertEquals(1, portalNavigationIconMigration.getMigratedPortalNodeIconsNodeIcons());
+    nodeEntity = nodeDAO.find(nodeEntity.getId());
+    assertNotNull(nodeEntity);
+    assertNotNull(nodeEntity.getIcon());
+    assertEquals("fas fa-user-lock", nodeEntity.getIcon());
+  }
+
+}

--- a/data-upgrade-navigations/src/test/java/org/exoplatform/migration/PortalNavigationIconMigrationTest.java
+++ b/data-upgrade-navigations/src/test/java/org/exoplatform/migration/PortalNavigationIconMigrationTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2024 eXo Platform SAS.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.exoplatform.migration;
 
 import org.junit.After;


### PR DESCRIPTION

Prior to this change after migrating from the 6.4 to the 6.5 then to the 6.6 version , the external stream node navigation icon was incorrect , this change is going to configure the PortalNavigationIconUpgradePlugin in order to set icons for the portal navigation nodes .