### PR TITLE
fix: Update the UpgradeSpaceNavigationIconPlugin after updating the plugin type - EXO-69389 - Meeds-io/meeds#1677

### DIFF
--- a/data-upgrade-navigations/src/main/resources/conf/portal/configuration.xml
+++ b/data-upgrade-navigations/src/main/resources/conf/portal/configuration.xml
@@ -165,8 +165,8 @@
         </value-param>
         <value-param>
           <name>plugin.upgrade.target.version</name>
-          <description>The plugin target version (will not be executed if previous version is equal or higher than 6.5.0)</description>
-          <value>6.6.0</value>
+          <description>The plugin target version (will not be executed if previous version is equal or higher than 6.5.2)</description>
+          <value>6.5.2</value>
         </value-param>
         <value-param>
           <name>space.node.names</name>

--- a/data-upgrade-navigations/src/main/resources/conf/portal/configuration.xml
+++ b/data-upgrade-navigations/src/main/resources/conf/portal/configuration.xml
@@ -153,7 +153,7 @@
       </init-params>
     </component-plugin>
     <component-plugin>
-      <name>SpaceNavigationIconUpgradePlugin</name>
+      <name>SpaceNavigationIconMigration</name>
       <set-method>addUpgradePlugin</set-method>
       <type>io.meeds.social.core.upgrade.SpaceNavigationIconUpgradePlugin</type>
       <description>Configure space node icons</description>
@@ -166,7 +166,7 @@
         <value-param>
           <name>plugin.upgrade.target.version</name>
           <description>The plugin target version (will not be executed if previous version is equal or higher than 6.5.0)</description>
-          <value>6.5.0</value>
+          <value>6.6.0</value>
         </value-param>
         <value-param>
           <name>space.node.names</name>


### PR DESCRIPTION


Prior to this change, after updating the space navigation upgrade plugin type to resolve the PostgreSQL issue, the stream navigation icon was not updated following the migration context. This issue arose due to the query which did not retrieve the stream navigation correctly for updating it. This change will update the query to set the stream navigation icon (Meeds-io/social#3548) and update the plugin configuration to be re-executed, resolving this issue