### PR TITLE
fix: Update to JDK21 - EXO-71474 - Meeds-io/MIPs#91

### DIFF
--- a/data-upgrade-ecms/src/main/java/org/exoplatform/ecms/upgrade/templates/NodeTypeTemplateUpgradePlugin.java
+++ b/data-upgrade-ecms/src/main/java/org/exoplatform/ecms/upgrade/templates/NodeTypeTemplateUpgradePlugin.java
@@ -30,7 +30,6 @@ import org.apache.commons.lang3.StringUtils;
 import org.exoplatform.commons.info.MissingProductInformationException;
 import org.exoplatform.commons.info.ProductInformations;
 import org.exoplatform.commons.upgrade.UpgradeProductPlugin;
-import org.exoplatform.commons.utils.PrivilegedSystemHelper;
 import org.exoplatform.commons.version.util.VersionComparator;
 import org.exoplatform.container.xml.InitParams;
 import org.exoplatform.services.cms.templates.TemplateService;
@@ -76,7 +75,7 @@ public class NodeTypeTemplateUpgradePlugin extends UpgradeProductPlugin {
     if (log.isInfoEnabled()) {
       log.info("Start " + this.getClass().getName() + ".............");
     }
-    String unchangedNodeTypes = PrivilegedSystemHelper.getProperty(UNCHANG_NODE_TYPES_CONFIG);
+    String unchangedNodeTypes = System.getProperty(UNCHANG_NODE_TYPES_CONFIG);
     String previousPlfVersion = PRODUCT_VERSION_ZERO;
     Set<String> modifiedTemplateLog = new HashSet<String>();
     try {

--- a/data-upgrade-ecms/src/main/java/org/exoplatform/ecms/upgrade/templates/WCMTemplateUpgradePlugin.java
+++ b/data-upgrade-ecms/src/main/java/org/exoplatform/ecms/upgrade/templates/WCMTemplateUpgradePlugin.java
@@ -29,7 +29,6 @@ import javax.jcr.query.QueryManager;
 import org.apache.commons.lang3.StringUtils;
 
 import org.exoplatform.commons.upgrade.UpgradeProductPlugin;
-import org.exoplatform.commons.utils.PrivilegedSystemHelper;
 import org.exoplatform.container.xml.InitParams;
 import org.exoplatform.services.cms.views.ApplicationTemplateManagerService;
 import org.exoplatform.services.cms.views.impl.ApplicationTemplateManagerServiceImpl;
@@ -51,8 +50,8 @@ public class WCMTemplateUpgradePlugin extends UpgradeProductPlugin {
     if (log.isInfoEnabled()) {
       log.info("Start " + this.getClass().getName() + ".............");
     }
-    String unchangedClvTemplates = PrivilegedSystemHelper.getProperty("unchanged-clv-templates");
-    String unchangedSearchTemplates = PrivilegedSystemHelper.getProperty("unchanged-wcm-search-templates");
+    String unchangedClvTemplates = System.getProperty("unchanged-clv-templates");
+    String unchangedSearchTemplates = System.getProperty("unchanged-wcm-search-templates");
     upgrade(unchangedClvTemplates, "content-list-viewer");
     upgrade(unchangedSearchTemplates, "search");
     

--- a/data-upgrade-ecms/src/main/java/org/exoplatform/ecms/upgrade/views/SiteExplorerTemplateUpgradePlugin.java
+++ b/data-upgrade-ecms/src/main/java/org/exoplatform/ecms/upgrade/views/SiteExplorerTemplateUpgradePlugin.java
@@ -28,7 +28,6 @@ import javax.jcr.Session;
 import org.apache.commons.lang3.StringUtils;
 
 import org.exoplatform.commons.upgrade.UpgradeProductPlugin;
-import org.exoplatform.commons.utils.PrivilegedSystemHelper;
 import org.exoplatform.container.xml.InitParams;
 import org.exoplatform.services.cms.BasePath;
 import org.exoplatform.services.cms.impl.DMSConfiguration;
@@ -87,7 +86,7 @@ public class SiteExplorerTemplateUpgradePlugin extends UpgradeProductPlugin {
     long startupTime = System.currentTimeMillis();
     log.info("Start upgrade of site explorer templates");
 
-    String unchangedViews = PrivilegedSystemHelper.getProperty("unchanged-site-explorer-templates");
+    String unchangedViews = System.getProperty("unchanged-site-explorer-templates");
     SessionProvider sessionProvider = null;
     if (StringUtils.isEmpty(unchangedViews)) {
       unchangedViews = "";


### PR DESCRIPTION
Remove usage of SecurityManager as it is deprecated for removal in jdk21 Remove also usage of classes
- SecurityHelper
- PrivilegedSystemHelper
- PrivilegedFileHelper
- SecureList
- SecureSet
- SecureCollections

These classes are here only to use securityManager, and as it is removed, it is no more necessary