### PR TITLE
feat: Implement Portal pages profiles and configure page migration upgrade plugin to upgrade content pages  - EXO-71740 - Meeds-io/MIPs#130

### DIFF
--- a/data-upgrade-app-registry/src/main/resources/conf/portal/configuration.xml
+++ b/data-upgrade-app-registry/src/main/resources/conf/portal/configuration.xml
@@ -114,6 +114,122 @@
         </value-param>
       </init-params>
     </component-plugin>
+    <component-plugin profiles="content">
+      <name>ContentNewsListViewAppRegistryUpgradePlugin</name>
+      <set-method>addUpgradePlugin</set-method>
+      <type>org.exoplatform.application.upgrade.AppRegistryUpgradePlugin</type>
+      <description>Upgrade App registry application</description>
+      <init-params>
+        <value-param>
+          <name>product.group.id</name>
+          <description>The groupId of the product</description>
+          <value>org.exoplatform.platform</value>
+        </value-param>
+        <value-param>
+          <name>plugin.upgrade.target.version</name>
+          <description>The plugin target version of selected groupId</description>
+          <value>7.0.0</value>
+        </value-param>
+        <value-param>
+          <name>plugin.execution.order</name>
+          <description>The plugin execution order</description>
+          <value>10</value>
+        </value-param>
+        <value-param>
+          <name>plugin.upgrade.execute.once</name>
+          <description>The plugin must be executed only once</description>
+          <value>true</value>
+        </value-param>
+        <value-param>
+          <name>plugin.upgrade.async.execution</name>
+          <description>The plugin will be executed in an asynchronous mode</description>
+          <value>true</value>
+        </value-param>
+        <value-param>
+          <name>old.content.id</name>
+          <description>The plugin will replace this app content by the new one</description>
+          <value>news/NewsListView</value>
+        </value-param>
+        <value-param>
+          <name>new.description</name>
+          <description>The plugin will replace this app description by the new one</description>
+          <value>Allows to display published articles on pages. The news list view portlet must be configured by choosing a target and a template.</value>
+        </value-param>
+        <value-param>
+          <name>new.display.name</name>
+          <description>The plugin will replace this app display name by the new one</description>
+          <value>News List View</value>
+        </value-param>
+        <value-param>
+          <name>new.app.name</name>
+          <description>The plugin will replace this app name by the new one</description>
+          <value>NewsListView</value>
+        </value-param>
+        <value-param>
+          <name>new.content.id</name>
+          <description>The plugin will replace this app contentId by the new one</description>
+          <value>content/NewsListView</value>
+        </value-param>
+      </init-params>
+    </component-plugin>
+    <component-plugin profiles="content">
+      <name>ContentNewsDetailsAppRegistryUpgradePlugin</name>
+      <set-method>addUpgradePlugin</set-method>
+      <type>org.exoplatform.application.upgrade.AppRegistryUpgradePlugin</type>
+      <description>Upgrade App registry application</description>
+      <init-params>
+        <value-param>
+          <name>product.group.id</name>
+          <description>The groupId of the product</description>
+          <value>org.exoplatform.platform</value>
+        </value-param>
+        <value-param>
+          <name>plugin.upgrade.target.version</name>
+          <description>The plugin target version of selected groupId</description>
+          <value>7.0.0</value>
+        </value-param>
+        <value-param>
+          <name>plugin.execution.order</name>
+          <description>The plugin execution order</description>
+          <value>20</value>
+        </value-param>
+        <value-param>
+          <name>plugin.upgrade.execute.once</name>
+          <description>The plugin must be executed only once</description>
+          <value>true</value>
+        </value-param>
+        <value-param>
+          <name>plugin.upgrade.async.execution</name>
+          <description>The plugin will be executed in an asynchronous mode</description>
+          <value>true</value>
+        </value-param>
+        <value-param>
+          <name>old.content.id</name>
+          <description>The plugin will replace this app content by the new one</description>
+          <value>news/NewsDetail</value>
+        </value-param>
+        <value-param>
+          <name>new.description</name>
+          <description>The plugin will replace this app description by the new one</description>
+          <value>Allows to display the detail of a news article</value>
+        </value-param>
+        <value-param>
+          <name>new.display.name</name>
+          <description>The plugin will replace this app display name by the new one</description>
+          <value>News Details</value>
+        </value-param>
+        <value-param>
+          <name>new.app.name</name>
+          <description>The plugin will replace this app name by the new one</description>
+          <value>NewsDetail</value>
+        </value-param>
+        <value-param>
+          <name>new.content.id</name>
+          <description>The plugin will replace this app contentId by the new one</description>
+          <value>content/NewsDetail</value>
+        </value-param>
+      </init-params>
+    </component-plugin>
   </external-component-plugins>
 </configuration>
 

--- a/data-upgrade-pages/src/main/java/org/exoplatform/migration/PortalPagesProfilesMigration.java
+++ b/data-upgrade-pages/src/main/java/org/exoplatform/migration/PortalPagesProfilesMigration.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright (C) 2024 eXo Platform SAS.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.exoplatform.migration;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.Query;
+import org.exoplatform.commons.persistence.impl.EntityManagerService;
+import org.exoplatform.commons.upgrade.UpgradeProductPlugin;
+import org.exoplatform.container.ExoContainerContext;
+import org.exoplatform.container.PortalContainer;
+import org.exoplatform.container.component.RequestLifeCycle;
+import org.exoplatform.container.xml.InitParams;
+import org.exoplatform.services.log.ExoLogger;
+import org.exoplatform.services.log.Log;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+public class PortalPagesProfilesMigration extends UpgradeProductPlugin {
+
+  private static final Log     LOG               = ExoLogger.getExoLogger(PortalPagesProfilesMigration.class);
+
+  private static final String  OLD_PAGES_PROFILES = "old.pages.profiles";
+
+  private static final String  NEW_PAGES_PROFILES = "new.pages.profiles";
+
+  private PortalContainer      container;
+
+  private EntityManagerService entityManagerService;
+
+  private Map<String, String>  pagesProfiles     = new HashMap<>();
+
+  private int                  pagesUpdatedCount;
+
+  public PortalPagesProfilesMigration(PortalContainer container, EntityManagerService entityManagerService, InitParams initParams) {
+    super(initParams);
+    this.container = container;
+    this.entityManagerService = entityManagerService;
+
+    if (initParams.containsKey(OLD_PAGES_PROFILES) && initParams.containsKey(NEW_PAGES_PROFILES)) {
+      pagesProfiles.put(initParams.getValueParam(OLD_PAGES_PROFILES).getValue(),
+                        initParams.getValueParam(NEW_PAGES_PROFILES).getValue());
+    }
+  }
+
+  @Override
+  public void processUpgrade(String s, String s1) {
+    if (pagesProfiles.isEmpty()) {
+      LOG.error("Couldn't process upgrade, the parameter '{}' is mandatory", OLD_PAGES_PROFILES);
+      return;
+    }
+
+    long startupTime = System.currentTimeMillis();
+
+    ExoContainerContext.setCurrentContainer(container);
+    boolean transactionStarted = false;
+
+    Set<Map.Entry<String, String>> pageProfilesEntrySet = pagesProfiles.entrySet();
+    for (Map.Entry<String, String> profiles : pageProfilesEntrySet) {
+      String oldPagesProfiles = profiles.getKey().trim();
+      String newPagesProfiles = profiles.getValue().trim();
+      LOG.info("Start upgrade of pages with profiles '{}' to use profiles '{}'", oldPagesProfiles, newPagesProfiles);
+      RequestLifeCycle.begin(this.entityManagerService);
+      EntityManager entityManager = this.entityManagerService.getEntityManager();
+      try {
+        if (!entityManager.getTransaction().isActive()) {
+          entityManager.getTransaction().begin();
+          transactionStarted = true;
+        }
+
+        String sqlString = "UPDATE PORTAL_PAGES  SET PROFILES = '" + newPagesProfiles + "' WHERE PROFILES = '" + oldPagesProfiles
+            + "' AND ID > 0;";
+        Query nativeQuery = entityManager.createNativeQuery(sqlString);
+        this.pagesUpdatedCount = nativeQuery.executeUpdate();
+        LOG.info("End upgrade of '{}' pages with profiles '{}' to use profiles '{}'. It took {} ms",
+                 pagesUpdatedCount,
+                 oldPagesProfiles,
+                 newPagesProfiles,
+                 (System.currentTimeMillis() - startupTime));
+        if (transactionStarted && entityManager.getTransaction().isActive()) {
+          entityManager.getTransaction().commit();
+          entityManager.flush();
+        }
+      } catch (Exception e) {
+        if (transactionStarted && entityManager.getTransaction().isActive() && entityManager.getTransaction().getRollbackOnly()) {
+          entityManager.getTransaction().rollback();
+        }
+      } finally {
+        RequestLifeCycle.end();
+      }
+    }
+  }
+
+  public int getPagesUpdatedCount() {
+    return pagesUpdatedCount;
+  }
+}

--- a/data-upgrade-pages/src/main/resources/conf/portal/configuration.xml
+++ b/data-upgrade-pages/src/main/resources/conf/portal/configuration.xml
@@ -639,5 +639,89 @@
       </init-params>
     </component-plugin>
 
+    <component-plugin profiles="content">
+      <name>ContentPagesUpgradePlugin</name>
+      <set-method>addUpgradePlugin</set-method>
+      <type>org.exoplatform.migration.PagesMigration</type>
+      <description>Replaces the application reference to old content application with the new application</description>
+      <init-params>
+        <value-param>
+          <name>product.group.id</name>
+          <description>The groupId of the product</description>
+          <value>org.exoplatform.platform</value>
+        </value-param>
+        <value-param>
+          <name>plugin.upgrade.target.version</name>
+          <description>The plugin target version of selected groupId</description>
+          <value>7.0.0</value>
+        </value-param>
+        <value-param>
+          <name>plugin.execution.order</name>
+          <description>The plugin execution order</description>
+          <value>50</value>
+        </value-param>
+        <value-param>
+          <name>plugin.upgrade.execute.once</name>
+          <description>The plugin must be executed only once</description>
+          <value>true</value>
+        </value-param>
+        <value-param>
+          <name>plugin.upgrade.async.execution</name>
+          <description>The plugin will be executed in an asynchronous mode</description>
+          <value>true</value>
+        </value-param>
+        <values-param>
+          <name>application.contentIds</name>
+          <description>The plugin will replace the pages by content application</description>
+          <value>news/newsPublishTargetsManagement:content/newsPublishTargetsManagement</value>
+          <value>news/NewsDetail:content/NewsDetail</value>
+          <value>news/NewsComposer:content/NewsComposer</value>
+          <value>news/NewsListView:content/NewsListView</value>
+        </values-param>
+      </init-params>
+    </component-plugin>
+
+    <component-plugin profiles="content">
+      <name>ContentPagesProfilesUpgradePlugin</name>
+      <set-method>addUpgradePlugin</set-method>
+      <type>org.exoplatform.migration.PortalPagesProfilesMigration</type>
+      <description>Replaces the old pages profiles with the new profiles</description>
+      <init-params>
+        <value-param>
+          <name>product.group.id</name>
+          <description>The groupId of the product</description>
+          <value>org.exoplatform.platform</value>
+        </value-param>
+        <value-param>
+          <name>plugin.upgrade.target.version</name>
+          <description>The plugin target version of selected groupId</description>
+          <value>7.0.0</value>
+        </value-param>
+        <value-param>
+          <name>plugin.execution.order</name>
+          <description>The plugin execution order</description>
+          <value>60</value>
+        </value-param>
+        <value-param>
+          <name>plugin.upgrade.execute.once</name>
+          <description>The plugin must be executed only once</description>
+          <value>true</value>
+        </value-param>
+        <value-param>
+          <name>plugin.upgrade.async.execution</name>
+          <description>The plugin will be executed in an asynchronous mode</description>
+          <value>true</value>
+        </value-param>
+        <value-param>
+          <name>old.pages.profiles</name>
+          <value>news</value>
+        </value-param>
+        <value-param>
+          <name>new.pages.profiles</name>
+          <value>content</value>
+        </value-param>
+      </init-params>
+    </component-plugin>
+
   </external-component-plugins>
 </configuration>

--- a/data-upgrade-pages/src/test/java/org/exoplatform/migration/PortalPagesProfilesMigrationTest.java
+++ b/data-upgrade-pages/src/test/java/org/exoplatform/migration/PortalPagesProfilesMigrationTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (C) 2024 eXo Platform SAS.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.exoplatform.migration;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.EntityTransaction;
+import jakarta.persistence.Query;
+import org.exoplatform.commons.persistence.impl.EntityManagerService;
+import org.exoplatform.container.PortalContainer;
+import org.exoplatform.container.xml.InitParams;
+import org.exoplatform.container.xml.ValueParam;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class PortalPagesProfilesMigrationTest {
+
+  @Mock
+  private PortalContainer       container;
+
+  @Mock
+  private EntityManagerService  entityManagerService;
+
+  @Mock
+  private EntityManager         entityManager;
+
+  @Mock
+  private EntityTransaction     transaction;
+
+  @Mock
+  private Query                 query;
+
+  private PortalPagesProfilesMigration portalPagesProfilesMigration;
+
+  @Test
+  public void testProcessUpgrade() {
+    InitParams initParams = new InitParams();
+    ValueParam valueParam = new ValueParam();
+    valueParam.setName("product.group.id");
+    valueParam.setValue("org.exoplatform.platform");
+    initParams.addParameter(valueParam);
+    valueParam = new ValueParam();
+    valueParam.setName("old.pages.profiles");
+    valueParam.setValue("oldPagesProfiles");
+    initParams.addParameter(valueParam);
+    valueParam = new ValueParam();
+    valueParam.setName("new.pages.profiles");
+    valueParam.setValue("newPagesProfiles");
+    initParams.addParameter(valueParam);
+
+    portalPagesProfilesMigration = new PortalPagesProfilesMigration(container, entityManagerService, initParams);
+
+    when(entityManagerService.getEntityManager()).thenReturn(entityManager);
+    when(entityManager.getTransaction()).thenReturn(transaction);
+    when(transaction.isActive()).thenReturn(false).thenReturn(true);
+    when(entityManager.createNativeQuery(anyString())).thenReturn(query);
+    when(query.executeUpdate()).thenReturn(10);
+
+    // Invoke the method
+    portalPagesProfilesMigration.processUpgrade("6.5", "7.0");
+
+    // Verify the transaction management and query execution
+    String expectedQuery = "UPDATE PORTAL_PAGES  SET PROFILES = 'newPagesProfiles' WHERE PROFILES = 'oldPagesProfiles' AND ID > 0;";
+    verify(transaction, times(2)).isActive();
+    verify(transaction).begin();
+    verify(entityManager, times(1)).createNativeQuery(expectedQuery);
+    verify(query).executeUpdate();
+    verify(transaction, times(1)).commit();
+    verify(entityManager, times(1)).flush();
+
+    // Assert the number of updated pages
+    assertEquals(10, portalPagesProfilesMigration.getPagesUpdatedCount());
+  }
+}


### PR DESCRIPTION
After migrating the content pages to the Meeds global site, this pull request implements the following changes : 

1. Introduce a new upgrade plugin named PortalPagesProfilesUpgradePlugin to update the profiles of the content pages.
2. Configure the existing application registry upgrade plugin to update the content ID of the application.
3. Configure the existing upgrade plugin to update the pages window content ID