### PR TITLE
fix: Fix Portal Storage Cache DTO constructor used in test - MEED-7060 - Meeds-io/MIPs#143

### DIFF
--- a/data-upgrade-navigations/src/test/java/org/exoplatform/migration/NavigationNodesMigrationTest.java
+++ b/data-upgrade-navigations/src/test/java/org/exoplatform/migration/NavigationNodesMigrationTest.java
@@ -163,7 +163,7 @@ public class NavigationNodesMigrationTest extends AbstractKernelTest {
                                                 "",
                                                 "",
                                                 "",
-                                                "",
+                                                null,
                                                 Collections.emptyList(),
                                                 Collections.emptyList(),
                                                 Collections.emptyList(),

--- a/data-upgrade-navigations/src/test/java/org/exoplatform/migration/PortalConfigPermissionMigrationTest.java
+++ b/data-upgrade-navigations/src/test/java/org/exoplatform/migration/PortalConfigPermissionMigrationTest.java
@@ -109,7 +109,7 @@ public class PortalConfigPermissionMigrationTest extends AbstractKernelTest {
                 "",
                 "",
                 "",
-                "",
+                null,
                 Collections.emptyList(),
                 Collections.emptyList(),
                 Collections.emptyList(),


### PR DESCRIPTION
( Resolves https://github.com/Meeds-io/MIPs/issues/143 )