### PR TITLE
fix: Fix NewsArticlesUpgrade execution for eXo 7.0.x fresh install - EXO-72583

### DIFF
--- a/data-upgrade-news/src/main/java/org/exoplatform/news/upgrade/jcr/NewsArticlesUpgrade.java
+++ b/data-upgrade-news/src/main/java/org/exoplatform/news/upgrade/jcr/NewsArticlesUpgrade.java
@@ -48,6 +48,7 @@ import org.exoplatform.container.xml.InitParams;
 import org.exoplatform.services.jcr.RepositoryService;
 import org.exoplatform.services.jcr.ext.app.SessionProviderService;
 import org.exoplatform.services.jcr.ext.common.SessionProvider;
+import org.exoplatform.services.jcr.impl.core.nodetype.NodeTypeManagerImpl;
 import org.exoplatform.services.log.ExoLogger;
 import org.exoplatform.services.log.Log;
 import org.exoplatform.services.security.IdentityConstants;
@@ -142,31 +143,38 @@ public class NewsArticlesUpgrade extends UpgradeProductPlugin {
                                                                     .getDefaultWorkspaceName(),
                                                    repositoryService.getCurrentRepository());
 
-      String queryString = "SELECT * FROM exo:news WHERE jcr:path LIKE '/Groups/spaces/%/News/%' order by exo:dateModified DESC";
-      QueryManager queryManager = session.getWorkspace().getQueryManager();
-      Query query = queryManager.createQuery(queryString, Query.SQL);
+      NodeTypeManagerImpl ntManager = (NodeTypeManagerImpl) session.getWorkspace().getNodeTypeManager();
+      if (ntManager.hasNodeType("exo:news")) {
+        String queryString =
+                           "SELECT * FROM exo:news WHERE jcr:path LIKE '/Groups/spaces/%/News/%' order by exo:dateModified DESC";
+        QueryManager queryManager = session.getWorkspace().getQueryManager();
+        Query query = queryManager.createQuery(queryString, Query.SQL);
 
-      Iterator<Node> newsIterator = query.execute().getNodes();
-      List<Node> newsArticlesNodes = new ArrayList<Node>();
-      while (newsIterator.hasNext()) {
-        Node newsArticleNode = newsIterator.next();
-        if (!newsArticleNode.hasProperty("exo:archived") || !newsArticleNode.getProperty("exo:archived").getBoolean()) {
-          newsArticlesNodes.add(newsArticleNode);
+        Iterator<Node> newsIterator = query.execute().getNodes();
+        List<Node> newsArticlesNodes = new ArrayList<Node>();
+        while (newsIterator.hasNext()) {
+          Node newsArticleNode = newsIterator.next();
+          if (!getBooleanProperty(newsArticleNode, "exo:archived")) {
+            newsArticlesNodes.add(newsArticleNode);
+          } else {
+            newsArticleNode.remove();
+            session.save();
+          }
         }
-      }
-      totalNewsArticlesCount = newsArticlesNodes.size();
-      LOG.info("Total number of news articles to be migrated: {}", totalNewsArticlesCount);
-      for (List<Node> newsArticlesChunk : ListUtils.partition(newsArticlesNodes, 10)) {
-        int notMigratedNewsArticlesCountByTransaction = manageNewsArticles(newsArticlesChunk, session);
-        int processedNewsArticlesCountByTransaction = newsArticlesChunk.size();
-        processedNewsArticlesCount += processedNewsArticlesCountByTransaction;
-        migratedNewsArticlesCount += processedNewsArticlesCountByTransaction - notMigratedNewsArticlesCountByTransaction;
-        notMigratedNewsArticlesCount += notMigratedNewsArticlesCountByTransaction;
-        LOG.info("News articles migration progress: processed={}/{} succeeded={} error={}",
-                 processedNewsArticlesCount,
-                 totalNewsArticlesCount,
-                 migratedNewsArticlesCount,
-                 notMigratedNewsArticlesCount);
+        totalNewsArticlesCount = newsArticlesNodes.size();
+        LOG.info("Total number of news articles to be migrated: {}", totalNewsArticlesCount);
+        for (List<Node> newsArticlesChunk : ListUtils.partition(newsArticlesNodes, 10)) {
+          int notMigratedNewsArticlesCountByTransaction = manageNewsArticles(newsArticlesChunk, session);
+          int processedNewsArticlesCountByTransaction = newsArticlesChunk.size();
+          processedNewsArticlesCount += processedNewsArticlesCountByTransaction;
+          migratedNewsArticlesCount += processedNewsArticlesCountByTransaction - notMigratedNewsArticlesCountByTransaction;
+          notMigratedNewsArticlesCount += notMigratedNewsArticlesCountByTransaction;
+          LOG.info("News articles migration progress: processed={}/{} succeeded={} error={}",
+                   processedNewsArticlesCount,
+                   totalNewsArticlesCount,
+                   migratedNewsArticlesCount,
+                   notMigratedNewsArticlesCount);
+        }
       }
     } catch (Exception e) {
       LOG.error("An error occurred when upgrading news articles:", e);
@@ -408,7 +416,8 @@ public class NewsArticlesUpgrade extends UpgradeProductPlugin {
         String newsActivityId = newsActivity.split(":")[1];
         ExoSocialActivity activity = activityManager.getActivity(newsActivityId);
         if (activity != null) {
-          Map<String, String> templateParams = activity.getTemplateParams() == null ? new HashMap<>() : activity.getTemplateParams();
+          Map<String, String> templateParams = activity.getTemplateParams() == null ? new HashMap<>()
+                                                                                    : activity.getTemplateParams();
           templateParams.put("newsId", article.getId());
           activity.setTemplateParams(templateParams);
           activity.setMetadataObjectId(article.getId());

--- a/data-upgrade-news/src/test/java/org/exoplatform/news/upgrade/jcr/NewsArticlesUpgradeTest.java
+++ b/data-upgrade-news/src/test/java/org/exoplatform/news/upgrade/jcr/NewsArticlesUpgradeTest.java
@@ -39,6 +39,8 @@ import javax.jcr.Property;
 import javax.jcr.Session;
 import javax.jcr.Value;
 import javax.jcr.Workspace;
+import javax.jcr.nodetype.NodeType;
+import javax.jcr.nodetype.NodeTypeManager;
 import javax.jcr.query.Query;
 import javax.jcr.query.QueryManager;
 import javax.jcr.query.QueryResult;
@@ -61,6 +63,7 @@ import org.exoplatform.services.jcr.config.RepositoryEntry;
 import org.exoplatform.services.jcr.core.ManageableRepository;
 import org.exoplatform.services.jcr.ext.app.SessionProviderService;
 import org.exoplatform.services.jcr.ext.common.SessionProvider;
+import org.exoplatform.services.jcr.impl.core.nodetype.NodeTypeManagerImpl;
 import org.exoplatform.services.wcm.extensions.publication.lifecycle.authoring.AuthoringPublicationConstant;
 import org.exoplatform.social.core.activity.model.ExoSocialActivity;
 import org.exoplatform.social.core.manager.ActivityManager;
@@ -154,11 +157,14 @@ public class NewsArticlesUpgradeTest {
     when(sessionProviderService.getSystemSessionProvider(null)).thenReturn(sessionProvider);
     Session session = mock(Session.class);
     when(sessionProvider.getSession(anyString(), any())).thenReturn(session);
+    Workspace workspace = mock(Workspace.class);
+    when(session.getWorkspace()).thenReturn(workspace);
+    NodeTypeManagerImpl nodetypeManager = mock(NodeTypeManagerImpl.class);
+    when(workspace.getNodeTypeManager()).thenReturn(nodetypeManager);
+    when(nodetypeManager.hasNodeType(anyString())).thenReturn(true);
 
     // Mock the query manager and query
     QueryManager queryManager = mock(QueryManager.class);
-    Workspace workspace = mock(Workspace.class);
-    when(session.getWorkspace()).thenReturn(workspace);
     when(workspace.getQueryManager()).thenReturn(queryManager);
     Query query = mock(Query.class);
     when(queryManager.createQuery(anyString(), eq(Query.SQL))).thenReturn(query);
@@ -178,6 +184,10 @@ public class NewsArticlesUpgradeTest {
 
     // Mock the necessary properties of the node1
     when(node1.hasProperty("publication:currentState")).thenReturn(true);
+    Property archivedProperty = mock(Property.class);
+    when(node1.hasProperty("exo:archived")).thenReturn(true);
+    when(node1.getProperty("exo:archived")).thenReturn(archivedProperty);
+    when(archivedProperty.getBoolean()).thenReturn(false);
     Property publishedStateProperty = mock(Property.class);
     when(node1.getProperty("publication:currentState")).thenReturn(publishedStateProperty);
     when(publishedStateProperty.getString()).thenReturn("published");


### PR DESCRIPTION
Prior to this change, when stating an eXo 7.0.x fresh install an exception javax.jcr.query.InvalidQueryException: Node type [[exoplatform.com/jcr/exo/1.0]news](http://www.exoplatform.com/jcr/exo/1.0]news) not found occurs with NewsArticlesUpgrade. After this fix, we ensure that the NewsArticlesUpgrade is executed only when exo:news nodetype exists.