### PR TITLE
fix : Error on upgrade plugin on startup - EXO-74356

### DIFF
--- a/data-upgrade-navigations/src/main/resources/conf/portal/configuration.xml
+++ b/data-upgrade-navigations/src/main/resources/conf/portal/configuration.xml
@@ -153,9 +153,9 @@
       </init-params>
     </component-plugin>
     <component-plugin>
-      <name>SpaceNavigationIconMigration</name>
+      <name>ExoSpaceNavigationIconMigration</name>
       <set-method>addUpgradePlugin</set-method>
-      <type>io.meeds.social.core.upgrade.SpaceNavigationIconUpgradePlugin</type>
+      <type>io.meeds.social.upgrade.SpaceNavigationIconUpgradePlugin</type>
       <description>Configure space node icons</description>
       <init-params>
         <value-param>


### PR DESCRIPTION
Before this fix, there is an error during startup on upgrade plugin due to error on package name This commit ensure to use the correct package name and rename the plugin configuration to not have a duplicated declaration