### PR TITLE
feat: Delete usage of Jcabi to use AspectJ Maven Plugin - MEED-7544 - Meeds-io/meeds#2417

### DIFF
--- a/data-upgrade-news/pom.xml
+++ b/data-upgrade-news/pom.xml
@@ -54,12 +54,4 @@
       <scope>provided</scope>
     </dependency>
   </dependencies>
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>com.jcabi</groupId>
-        <artifactId>jcabi-maven-plugin</artifactId>
-      </plugin>
-    </plugins>
-  </build>
 </project>


### PR DESCRIPTION
This change will delete the usage of Jcabi Maven plugin which is incompatible with newer AspectJ versions and use AspectJ Maven plugin instead