### PR TITLE
fix: Update the PublishedNewsImagesPermissionsUpgradePlugin to change the published news images permissions to be visible for users that are not in the space- EXO-71982

### DIFF
--- a/data-upgrade-news/src/main/resources/conf/portal/configuration.xml
+++ b/data-upgrade-news/src/main/resources/conf/portal/configuration.xml
@@ -256,9 +256,9 @@
     </component-plugin>
 
     <component-plugin>
-      <name>PublishedNewsImagesPermissionsUpgradePlugin</name>
+      <name>PublishedNewsImagesPermissionsV2UpgradePlugin</name>
       <set-method>addUpgradePlugin</set-method>
-      <type>org.exoplatform.news.upgrade.jcr.PublishedNewsImagesPermissionsUpgradePlugin</type>
+      <type>org.exoplatform.news.upgrade.jcr.PublishedNewsImagesPermissionsV2UpgradePlugin</type>
       <description>Update published news images permissions</description>
       <init-params>
         <value-param>


### PR DESCRIPTION
This fix reactivate the PublishedNewsImagesPermissionsUpgradePlugin to update all published news images permissions to be visible  for all users