### PR TITLE
fix - Create a new upgrade plugin to add remove permissions to recording files existing in private drive of users - EXO-75233 (#255)

### DIFF
--- a/data-upgrade-recordings-permissions/pom.xml
+++ b/data-upgrade-recordings-permissions/pom.xml
@@ -1,0 +1,43 @@
+<!-- Copyright (C) 2023 eXo Platform SAS. This is free software; you can
+  redistribute it and/or modify it under the terms of the GNU Lesser General 
+  Public License as published by the Free Software Foundation; either version 
+  2.1 of the License, or (at your option) any later version. This software 
+  is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; 
+  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR 
+  PURPOSE. See the GNU Lesser General Public License for more details. You 
+  should have received a copy of the GNU Lesser General Public License along 
+  with this software; if not, write to the Free Software Foundation, Inc., 
+  51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA, or see the FSF site: 
+  http://www.fsf.org. -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.exoplatform.addons.upgrade</groupId>
+    <artifactId>upgrade</artifactId>
+    <version>7.0.x-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>data-upgrade-recordings-permissions</artifactId>
+  <packaging>jar</packaging>
+  <name>eXo Add-on:: Data Upgrade Add-on - Recordings permissions</name>
+
+  <dependencies>
+    <dependency>
+      <groupId>io.meeds.commons</groupId>
+      <artifactId>commons-component-upgrade</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.exoplatform.jcr</groupId>
+      <artifactId>exo.jcr.component.core</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.exoplatform.jcr</groupId>
+      <artifactId>exo.jcr.component.ext</artifactId>
+      <scope>provided</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/data-upgrade-recordings-permissions/src/main/java/org/exoplatform/jcr/upgrade/RecordingsPermissionsUpgradePlugin.java
+++ b/data-upgrade-recordings-permissions/src/main/java/org/exoplatform/jcr/upgrade/RecordingsPermissionsUpgradePlugin.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright (C) 2003-2024 eXo Platform SAS
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <gnu.org/licenses>.
+ */
+package org.exoplatform.jcr.upgrade;
+
+import javax.jcr.Node;
+import javax.jcr.NodeIterator;
+import javax.jcr.Session;
+import javax.jcr.query.Query;
+import javax.jcr.query.QueryResult;
+
+import org.exoplatform.commons.upgrade.UpgradeProductPlugin;
+import org.exoplatform.container.PortalContainer;
+import org.exoplatform.container.component.RequestLifeCycle;
+import org.exoplatform.container.xml.InitParams;
+import org.exoplatform.services.jcr.RepositoryService;
+import org.exoplatform.services.jcr.access.PermissionType;
+import org.exoplatform.services.jcr.core.ExtendedNode;
+import org.exoplatform.services.jcr.ext.app.SessionProviderService;
+import org.exoplatform.services.jcr.ext.common.SessionProvider;
+import org.exoplatform.services.log.ExoLogger;
+import org.exoplatform.services.log.Log;
+import org.exoplatform.services.organization.OrganizationService;
+import org.exoplatform.services.organization.User;
+
+/**
+ * plugin will be executed in order to update recordings existing in users drive by adding delete permission
+ */
+public class RecordingsPermissionsUpgradePlugin extends UpgradeProductPlugin {
+
+  private static final Log log = ExoLogger.getLogger(RecordingsPermissionsUpgradePlugin.class.getName());
+
+  private OrganizationService organizationService;
+
+  private RepositoryService repositoryService;
+
+  private SessionProviderService sessionProviderService;
+
+  public RecordingsPermissionsUpgradePlugin(InitParams initParams,
+                                            OrganizationService organizationService,
+                                            RepositoryService repositoryService,
+                                            SessionProviderService sessionProviderService) {
+    super(initParams);
+    this.organizationService = organizationService;
+    this.repositoryService = repositoryService;
+    this.sessionProviderService = sessionProviderService;
+  }
+
+  @Override
+  public void processUpgrade(String oldVersion, String newVersion) {
+    long startupTime = System.currentTimeMillis();
+    int updatedRecordingsCount = 0;
+    long totalRecordingsCount = 0;
+    int totalBadPermissionRecordingsCount = 0;
+    log.info("Start upgrade : Updating recordings permissions");
+
+    SessionProvider sessionProvider = null;
+    RequestLifeCycle.begin(PortalContainer.getInstance());
+    try {
+      sessionProvider = sessionProviderService.getSystemSessionProvider(null);
+      Session session = sessionProvider.getSession(
+              repositoryService.getCurrentRepository()
+                      .getConfiguration()
+                      .getDefaultWorkspaceName(),
+              repositoryService.getCurrentRepository());
+      Node users = (Node) session.getItem("/Users");
+      String statement =
+              "SELECT * FROM nt:base WHERE jcr:path LIKE '%/Private/recordings/%' AND (jcr:primaryType='exo:symlink' OR jcr:primaryType='nt:file')";
+      Query jcrQuery = users.getSession().getWorkspace().getQueryManager().createQuery(statement, Query.SQL);
+      QueryResult queryResult = jcrQuery.execute();
+      NodeIterator nodeIterator = queryResult.getNodes();
+      totalRecordingsCount = nodeIterator.getSize();
+      log.info("Total number of recordings: {}", totalRecordingsCount);
+      while (nodeIterator.hasNext()) {
+        Node node = nodeIterator.nextNode();
+        String nodePath = node.getPath();
+        String[] pathParts = nodePath.substring(0, nodePath.indexOf("/Private")).split("/");
+        String userName = pathParts[pathParts.length - 1];
+        User user = organizationService.getUserHandler().findUserByName(userName);
+        if (user != null) {
+          boolean haveDeletePermission = ((ExtendedNode) node).getACL()
+                  .getPermissionEntries()
+                  .stream()
+                  .anyMatch(accessControlEntry -> accessControlEntry.getIdentity()
+                          .equals(userName)
+                          && accessControlEntry.getPermission().equals("remove"));
+          if (!haveDeletePermission) {
+            totalBadPermissionRecordingsCount += 1;
+            try {
+              if (node.canAddMixin("exo:privilegeable")) {
+                node.addMixin("exo:privilegeable");
+              }
+              ((ExtendedNode) node).setPermission(userName,
+                      new String[]{PermissionType.READ, PermissionType.ADD_NODE,
+                              PermissionType.SET_PROPERTY, PermissionType.REMOVE});
+              node.save();
+              updatedRecordingsCount += 1;
+              log.info("{} Recording permissions" +
+                              " updated.",
+                      updatedRecordingsCount);
+            } catch (Exception e) {
+              if (log.isErrorEnabled()) {
+                log.error("An unexpected error occurs when updating recording {} permissions:", node.getPath(), e);
+              }
+            }
+          }
+        }
+      }
+      log.info("End updating permissions of {}/{} recordings with bad permissions,  total number of checked records = {}. It took {} ms",
+              updatedRecordingsCount,
+              totalBadPermissionRecordingsCount,
+              totalRecordingsCount,
+              (System.currentTimeMillis() - startupTime));
+    } catch (Exception e) {
+      if (log.isErrorEnabled()) {
+        log.error("An unexpected error occurs when updating recordings permissions:", e);
+      }
+    } finally {
+      if (sessionProvider != null) {
+        sessionProvider.close();
+      }
+      RequestLifeCycle.end();
+    }
+  }
+
+}

--- a/data-upgrade-recordings-permissions/src/main/resources/conf/portal/configuration.xml
+++ b/data-upgrade-recordings-permissions/src/main/resources/conf/portal/configuration.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<!--
+
+    Copyright (C) 2003-2021 eXo Platform SAS.
+
+    This is free software; you can redistribute it and/or modify it
+    under the terms of the GNU Lesser General Public License as
+    published by the Free Software Foundation; either version 3 of
+    the License, or (at your option) any later version.
+
+    This software is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+    Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public
+    License along with this software; if not, write to the Free
+    Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+    02110-1301 USA, or see the FSF site: http://www.fsf.org.
+
+-->
+<configuration xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.exoplatform.org/xml/ns/kernel_1_3.xsd http://www.exoplatform.org/xml/ns/kernel_1_3.xsd" xmlns="http://www.exoplatform.org/xml/ns/kernel_1_3.xsd">
+
+  <external-component-plugins>
+    <target-component>org.exoplatform.commons.upgrade.UpgradeProductService</target-component>
+    <component-plugin  profiles="ecms">
+      <name>RecordingsPermissionsUpgradePlugin</name>
+      <set-method>addUpgradePlugin</set-method>
+      <type>org.exoplatform.jcr.upgrade.RecordingsPermissionsUpgradePlugin</type>
+      <description>upgrade personal recordings to add delete permissions</description>
+      <init-params>
+        <value-param>
+          <name>product.group.id</name>
+          <description>The groupId of the product</description>
+          <value>org.exoplatform.platform</value>
+        </value-param>
+        <value-param>
+          <name>plugin.upgrade.target.version</name>
+          <description>The plugin target version of selected groupId</description>
+          <value>7.0.0</value>
+        </value-param>
+        <value-param>
+          <name>plugin.execution.order</name>
+          <description>The plugin execution order</description>
+          <value>10</value>
+        </value-param>
+        <value-param>
+          <name>plugin.upgrade.execute.once</name>
+          <description>The plugin must be executed only once</description>
+          <value>true</value>
+        </value-param>
+        <value-param>
+          <name>plugin.upgrade.async.execution</name>
+          <description>The plugin will be executed in an asynchronous mode</description>
+          <value>true</value>
+        </value-param>
+      </init-params>
+    </component-plugin>
+  </external-component-plugins>
+</configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -29,6 +29,7 @@
     <module>data-upgrade-notifications</module>
     <module>data-upgrade-processes-permissions</module>
     <module>data-upgrade-move-folders</module>
+    <module>data-upgrade-recordings-permissions</module>
     <module>data-upgrade-packaging</module>
   </modules>
   <properties>


### PR DESCRIPTION
Before this commit, some existing recordings added under a user private drive cannot be deleted. It's because of the current user don't have the remove permission non these files. This upgrade plugin update these files bey adding the remove permission.