### PR TITLE
fix: Create a new upgrade plugin to add remove duplicated favorite applications - EXO-75399

### DIFF
--- a/data-upgrade-app-center/pom.xml
+++ b/data-upgrade-app-center/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.exoplatform.addons.upgrade</groupId>
         <artifactId>upgrade</artifactId>
-        <version>7.0.0</version>
+        <version>7.0.x-SNAPSHOT</version>
     </parent>
     <artifactId>data-upgrade-app-center</artifactId>
     <packaging>jar</packaging>

--- a/data-upgrade-app-center/pom.xml
+++ b/data-upgrade-app-center/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.exoplatform.addons.upgrade</groupId>
         <artifactId>upgrade</artifactId>
-        <version>7.0.x-maintenance-SNAPSHOT</version>
+        <version>7.0.0</version>
     </parent>
     <artifactId>data-upgrade-app-center</artifactId>
     <packaging>jar</packaging>

--- a/data-upgrade-app-center/pom.xml
+++ b/data-upgrade-app-center/pom.xml
@@ -1,0 +1,39 @@
+<!-- Copyright (C) 2023 eXo Platform SAS. This is free software; you can
+  redistribute it and/or modify it under the terms of the GNU Lesser General
+  Public License as published by the Free Software Foundation; either version
+  2.1 of the License, or (at your option) any later version. This software
+  is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+  PURPOSE. See the GNU Lesser General Public License for more details. You
+  should have received a copy of the GNU Lesser General Public License along
+  with this software; if not, write to the Free Software Foundation, Inc.,
+  51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA, or see the FSF site:
+  http://www.fsf.org. -->
+
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.exoplatform.addons.upgrade</groupId>
+        <artifactId>upgrade</artifactId>
+        <version>7.0.x-maintenance-SNAPSHOT</version>
+    </parent>
+    <artifactId>data-upgrade-app-center</artifactId>
+    <packaging>jar</packaging>
+    <name>eXo Add-on:: Data Upgrade Add-on - App center</name>
+    <properties>
+        <exo.test.coverage.ratio>0.84</exo.test.coverage.ratio>
+    </properties>
+    <dependencies>
+        <dependency>
+            <groupId>io.meeds.commons</groupId>
+            <artifactId>commons-component-upgrade</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.meeds.app-center</groupId>
+            <artifactId>app-center-services</artifactId>
+            <scope>compile</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/data-upgrade-app-center/src/main/java/org/exoplatform/upgrade/CleanFavoriteApplications.java
+++ b/data-upgrade-app-center/src/main/java/org/exoplatform/upgrade/CleanFavoriteApplications.java
@@ -1,0 +1,97 @@
+package org.exoplatform.upgrade;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.exoplatform.commons.api.persistence.ExoTransactional;
+import org.exoplatform.commons.persistence.impl.EntityManagerService;
+import org.exoplatform.commons.upgrade.UpgradeProductPlugin;
+import org.exoplatform.container.xml.InitParams;
+import org.exoplatform.services.log.ExoLogger;
+import org.exoplatform.services.log.Log;
+
+import io.meeds.appcenter.entity.ApplicationEntity;
+import io.meeds.appcenter.entity.FavoriteApplicationEntity;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.Query;
+
+public class CleanFavoriteApplications extends UpgradeProductPlugin {
+
+  private static final Log     log = ExoLogger.getLogger(CleanFavoriteApplications.class.getName());
+
+  private EntityManagerService entityManagerService;
+
+  public CleanFavoriteApplications(InitParams initParams, EntityManagerService entityManagerService) {
+    super(initParams);
+    this.entityManagerService = entityManagerService;
+  }
+
+  @Override
+  public void processUpgrade(String oldVersion, String newVersion) {
+    long startupTime = System.currentTimeMillis();
+    EntityManager entityManager = this.entityManagerService.getEntityManager();
+    List<Object[]> duplicatedFavoriteAppsEntityList = getDuplicatedFavoriteAppsEntityList(entityManager);
+    if (duplicatedFavoriteAppsEntityList.isEmpty()) {
+      return;
+    }
+    log.info("Start upgrade of cleaning for favorite applications, {} favorite applications should be deleted",
+             duplicatedFavoriteAppsEntityList.size());
+    Set<String> uniqueUserNames = new HashSet<>();
+    duplicatedFavoriteAppsEntityList.forEach(favoriteApplicationEntity -> uniqueUserNames.add((String) favoriteApplicationEntity[2]));
+    log.info("{} favorite applications duplicated for {} users", duplicatedFavoriteAppsEntityList.size(), uniqueUserNames.size());
+    int favoriteApplicationCount = cleanFavoriteApps(entityManager, duplicatedFavoriteAppsEntityList);
+    log.info("End upgrade : Deleted {} favorite applications done it took {} ms",
+             favoriteApplicationCount,
+             System.currentTimeMillis() - startupTime);
+  }
+
+  private List<Object[]> getDuplicatedFavoriteAppsEntityList(EntityManager entityManager) {
+    String selectQuery = "SELECT * FROM AC_FAVORITE_APPLICATION favoriteApp "
+        + "WHERE (favoriteApp.APPLICATION_ID, favoriteApp.USER_NAME) IN ("
+        + "    SELECT favoriteApplication.APPLICATION_ID, favoriteApplication.USER_NAME "
+        + "    FROM AC_FAVORITE_APPLICATION favoriteApplication "
+        + "    GROUP BY favoriteApplication.APPLICATION_ID, favoriteApplication.USER_NAME " + "    HAVING COUNT(*) > 1)";
+    Query nativeQuery = entityManager.createNativeQuery(selectQuery);
+    return nativeQuery.getResultList();
+  }
+
+  protected int cleanFavoriteApps(EntityManager entityManager, List<Object[]> duplicatedFavoriteApplicationsEntityList) {
+    List<FavoriteApplicationEntity> duplicatedFavoriteAppsEntityList =
+                                                                     toFavoriteAppsEntityList(duplicatedFavoriteApplicationsEntityList);
+    List<FavoriteApplicationEntity> favoriteAppsEntityList = new ArrayList<>();
+    int favoriteAppCount = 0;
+    for (FavoriteApplicationEntity favoriteApplicationEntity : duplicatedFavoriteAppsEntityList) {
+      FavoriteApplicationEntity favoriteAppEntityOfIdNull =
+                                                          new FavoriteApplicationEntity(0L,
+                                                                                        favoriteApplicationEntity.getApplication(),
+                                                                                        favoriteApplicationEntity.getUserName(),
+                                                                                        favoriteApplicationEntity.getOrder());
+      if (favoriteAppsEntityList.contains(favoriteAppEntityOfIdNull)) {
+        deleteFavoriteApplication(entityManager, favoriteApplicationEntity.getId());
+        favoriteAppCount += 1;
+      } else {
+        favoriteAppsEntityList.add(favoriteAppEntityOfIdNull);
+      }
+    }
+    return favoriteAppCount;
+  }
+
+  List<FavoriteApplicationEntity> toFavoriteAppsEntityList(List<Object[]> objects) {
+    List<FavoriteApplicationEntity> favoriteAppsEntityList = new ArrayList<>();
+    objects.forEach(object -> {
+      ApplicationEntity applicationEntity = new ApplicationEntity();
+      applicationEntity.setId((Long) object[1]);
+      favoriteAppsEntityList.add(new FavoriteApplicationEntity((Long) object[0], applicationEntity, (String) object[2], null));
+    });
+    return favoriteAppsEntityList;
+  }
+
+  @ExoTransactional
+  protected void deleteFavoriteApplication(EntityManager entityManager, Long favoriteApplicationId) {
+    String deleteQuery = "DELETE FROM AC_FAVORITE_APPLICATION WHERE ID = " + favoriteApplicationId;
+    Query query = entityManager.createNativeQuery(deleteQuery);
+    query.executeUpdate();
+  }
+}

--- a/data-upgrade-app-center/src/main/resources/conf/portal/configuration.xml
+++ b/data-upgrade-app-center/src/main/resources/conf/portal/configuration.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<!--
+
+    Copyright (C) 2003-2021 eXo Platform SAS.
+
+    This is free software; you can redistribute it and/or modify it
+    under the terms of the GNU Lesser General Public License as
+    published by the Free Software Foundation; either version 3 of
+    the License, or (at your option) any later version.
+
+    This software is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+    Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public
+    License along with this software; if not, write to the Free
+    Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+    02110-1301 USA, or see the FSF site: http://www.fsf.org.
+
+-->
+<configuration xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+               xsi:schemaLocation="http://www.exoplatform.org/xml/ns/kernel_1_3.xsd http://www.exoplatform.org/xml/ns/kernel_1_3.xsd"
+               xmlns="http://www.exoplatform.org/xml/ns/kernel_1_3.xsd">
+
+    <external-component-plugins>
+        <target-component>org.exoplatform.commons.upgrade.UpgradeProductService</target-component>
+        <component-plugin profiles="app-center">
+            <name>CleanFavoriteApplications</name>
+            <set-method>addUpgradePlugin</set-method>
+            <type>org.exoplatform.upgrade.CleanFavoriteApplications</type>
+            <description>Remove duplicated favorite applications for all users</description>
+            <init-params>
+                <value-param>
+                    <name>product.group.id</name>
+                    <description>The groupId of the product</description>
+                    <value>org.exoplatform.platform</value>
+                </value-param>
+                <value-param>
+                    <name>plugin.upgrade.target.version</name>
+                    <description>The plugin target version of selected groupId</description>
+                    <value>7.0.0</value>
+                </value-param>
+                <value-param>
+                    <name>plugin.execution.order</name>
+                    <description>The plugin execution order</description>
+                    <value>10</value>
+                </value-param>
+                <value-param>
+                    <name>plugin.upgrade.execute.once</name>
+                    <description>The plugin must be executed only once</description>
+                    <value>true</value>
+                </value-param>
+                <value-param>
+                    <name>plugin.upgrade.async.execution</name>
+                    <description>The plugin will be executed in an asynchronous mode</description>
+                    <value>true</value>
+                </value-param>
+            </init-params>
+        </component-plugin>
+    </external-component-plugins>
+</configuration>

--- a/data-upgrade-app-center/src/test/java/org/exoplatform/upgrade/CleanFavoriteApplicationsTest.java
+++ b/data-upgrade-app-center/src/test/java/org/exoplatform/upgrade/CleanFavoriteApplicationsTest.java
@@ -1,0 +1,69 @@
+package org.exoplatform.upgrade;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+import java.util.List;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import org.exoplatform.commons.persistence.impl.EntityManagerService;
+import org.exoplatform.container.xml.InitParams;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.Query;
+
+public class CleanFavoriteApplicationsTest {
+
+  @Mock
+  private EntityManagerService      entityManagerService;
+
+  @Mock
+  private EntityManager             entityManager;
+
+  @Mock
+  private Query                     query;
+
+  private CleanFavoriteApplications cleanFavoriteApplications;
+
+  @Before
+  public void setUp() {
+    MockitoAnnotations.openMocks(this);
+    InitParams initParams = new InitParams();
+    cleanFavoriteApplications = new CleanFavoriteApplications(initParams, entityManagerService);
+    when(entityManagerService.getEntityManager()).thenReturn(entityManager);
+  }
+
+  @Test
+  public void processUpgradeCleanDuplicatedFavoriteApps() {
+    List<Object[]> results = List.of(new Object[] { 1L, 100L, "user1" },
+                                     new Object[] { 2L, 100L, "user1" },
+                                     new Object[] { 3L, 101L, "test" },
+                                     new Object[] { 4L, 101L, "test" });
+
+    when(entityManager.createNativeQuery(anyString())).thenReturn(query);
+    when(query.getResultList()).thenReturn(results);
+    when(query.executeUpdate()).thenReturn(2);
+
+    cleanFavoriteApplications.processUpgrade("v1", "v1");
+
+    verify(entityManager, times(3)).createNativeQuery(anyString());
+    verify(query, times(2)).executeUpdate();
+    verify(entityManagerService, times(1)).getEntityManager();
+  }
+
+  @Test
+  public void processUpgradeNoDuplicatedFavoriteApps() {
+    List<Object[]> results = List.of(new Object[] { 1L, 100L, "user1" }, new Object[] { 2L, 101L, "test" });
+
+    when(entityManager.createNativeQuery(anyString())).thenReturn(query);
+    when(query.getResultList()).thenReturn(results);
+
+    cleanFavoriteApplications.processUpgrade("v1", "v1");
+
+    verify(query, never()).executeUpdate();
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -30,6 +30,7 @@
     <module>data-upgrade-processes-permissions</module>
     <module>data-upgrade-move-folders</module>
     <module>data-upgrade-recordings-permissions</module>
+    <module>data-upgrade-app-center</module>
     <module>data-upgrade-packaging</module>
   </modules>
   <properties>


### PR DESCRIPTION
Before this change, some users have duplicate favorite applications. To resolve this problem, create an upgrade plugin that fetches all duplicates and keeps one of each duplicate and removes the rest of the items. After this change, all duplicate favorite applications are removed for all users and one favorite application is kept from each duplicate.

(cherry picked from commit 51544d24ca740eb263293f74d110560d62667e42)