### PR TITLE
fix: Fix Wiki page name upgrade plugin test faied - MEED-Meeds-io/MIPs#157

### DIFF
--- a/data-upgrade-wiki/src/test/resources/conf/portal/configuration.xml
+++ b/data-upgrade-wiki/src/test/resources/conf/portal/configuration.xml
@@ -25,6 +25,7 @@
         xmlns="http://www.exoplatform.org/xml/ns/kernel_1_2.xsd">
 
   <import>jar:/conf/portal/wiki-configuration.xml</import>
+  <import>jar:/conf/portal/metadata-configuration.xml</import>
 
   <remove-configuration>org.exoplatform.wiki.service.NotesExportService</remove-configuration>
   <remove-configuration>org.exoplatform.wiki.service.rest.NotesRestService</remove-configuration>

--- a/data-upgrade-wiki/src/test/resources/conf/portal/metadata-configuration.xml
+++ b/data-upgrade-wiki/src/test/resources/conf/portal/metadata-configuration.xml
@@ -1,0 +1,45 @@
+<!--
+
+    Copyright (C) 2020 - 2025 eXo Platform SAS.
+
+    This program is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Affero General Public License
+    as published by the Free Software Foundation; either version 3
+    of the License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, see<http://www.gnu.org/licenses/>.
+
+-->
+<configuration
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.exoplatform.org/xml/ns/kernel_1_2.xsd http://www.exoplatform.org/xml/ns/kernel_1_2.xsd"
+        xmlns="http://www.exoplatform.org/xml/ns/kernel_1_2.xsd">
+
+  <external-component-plugins>
+    <target-component>org.exoplatform.social.metadata.MetadataService</target-component>
+    <component-plugin>
+      <name>NotesMetadataTypePlugin</name>
+      <set-method>addMetadataTypePlugin</set-method>
+      <type>org.exoplatform.social.metadata.MetadataTypePlugin</type>
+      <init-params>
+          <object-param>
+          <name>metadataType</name>
+          <object type="org.exoplatform.social.metadata.model.MetadataType">
+            <field name="id">
+              <int>1001</int>
+            </field>
+            <field name="name">
+              <string>notes</string>
+            </field>
+          </object>
+        </object-param>
+      </init-params>
+    </component-plugin>
+  </external-component-plugins>
+</configuration>


### PR DESCRIPTION
Before adding the T&C note page, we only built metadata pages when a space was defined. Since the T&C page is a system page without a space ID, it requires a storage metadata entry. Therefore, we need to build metadata for both cases