### PR TITLE
fix: Fix perf and jcr session timeout issues with NewsArticlesUpgrade - EXO-76992

### DIFF
--- a/data-upgrade-news/src/main/java/org/exoplatform/news/upgrade/jcr/NewsArticlesUpgrade.java
+++ b/data-upgrade-news/src/main/java/org/exoplatform/news/upgrade/jcr/NewsArticlesUpgrade.java
@@ -544,9 +544,9 @@ public class NewsArticlesUpgrade extends UpgradeProductPlugin {
 
         if (articleMetadataItem != null) {
           articleMetadataItem.setProperties(articleMetadataItemProperties);
-          metadataService.updateMetadataItem(articleMetadataItem, creatorId);
+          metadataService.updateMetadataItem(articleMetadataItem, creatorId, false);
         } else {
-          metadataService.createMetadataItem(articleMetaDataObject, NOTES_METADATA_KEY, articleMetadataItemProperties, creatorId);
+          metadataService.createMetadataItem(articleMetaDataObject, NOTES_METADATA_KEY, articleMetadataItemProperties, creatorId, false);
         }
       }
     }
@@ -570,7 +570,7 @@ public class NewsArticlesUpgrade extends UpgradeProductPlugin {
       }
       articleMetadataItemProperties.put("activities", articleActivities);
       articleMetadataItem.setProperties(articleMetadataItemProperties);
-      metadataService.updateMetadataItem(articleMetadataItem, articleMetadataItem.getCreatorId());
+      metadataService.updateMetadataItem(articleMetadataItem, articleMetadataItem.getCreatorId(), false);
       String newsActivity = articleActivities.split(";")[0];
       if (newsActivity.split(":").length > 1) {
         String newsActivityId = newsActivity.split(":")[1];
@@ -608,7 +608,7 @@ public class NewsArticlesUpgrade extends UpgradeProductPlugin {
       articleMetadataItemProperties.put("viewsCount", String.valueOf(articleViewsCount));
       articleMetadataItemProperties.put("viewers", articleViewers);
       articleMetadataItem.setProperties(articleMetadataItemProperties);
-      metadataService.updateMetadataItem(articleMetadataItem, articleMetadataItem.getCreatorId());
+      metadataService.updateMetadataItem(articleMetadataItem, articleMetadataItem.getCreatorId(), false);
     }
   }
 
@@ -650,7 +650,7 @@ public class NewsArticlesUpgrade extends UpgradeProductPlugin {
         }
         articleMetadataItemProperties.put("schedulePostDate", scheduledPostDate);
         articleMetadataItem.setProperties(articleMetadataItemProperties);
-        metadataService.updateMetadataItem(articleMetadataItem, articleMetadataItem.getCreatorId());
+        metadataService.updateMetadataItem(articleMetadataItem, articleMetadataItem.getCreatorId(), false);
       }
     }
   }
@@ -686,7 +686,7 @@ public class NewsArticlesUpgrade extends UpgradeProductPlugin {
         articleMetaData.setCreatedDate(createDate.getTime());
       }
       noteService.updateNote(articlePage);
-      metadataService.updateMetadataItem(articleMetaData, articleMetaData.getCreatorId());
+      metadataService.updateMetadataItem(articleMetaData, articleMetaData.getCreatorId(), false);
     }
   }
 

--- a/data-upgrade-news/src/main/java/org/exoplatform/news/upgrade/jcr/NewsArticlesUpgrade.java
+++ b/data-upgrade-news/src/main/java/org/exoplatform/news/upgrade/jcr/NewsArticlesUpgrade.java
@@ -37,16 +37,21 @@ import javax.jcr.query.Query;
 import javax.jcr.query.QueryManager;
 
 import io.meeds.notes.model.NotePageProperties;
+import jakarta.persistence.EntityManager;
+
 import org.apache.commons.collections4.ListUtils;
 
 import org.apache.commons.collections4.MapUtils;
 import org.apache.commons.lang3.StringUtils;
+
+import org.exoplatform.commons.api.persistence.ExoTransactional;
 import org.exoplatform.commons.api.settings.SettingService;
 import org.exoplatform.commons.api.settings.SettingValue;
 import org.exoplatform.commons.api.settings.data.Context;
 import org.exoplatform.commons.api.settings.data.Scope;
 import org.exoplatform.commons.file.model.FileItem;
 import org.exoplatform.commons.file.services.FileService;
+import org.exoplatform.commons.persistence.impl.EntityManagerService;
 import org.exoplatform.commons.search.index.IndexingService;
 import org.exoplatform.commons.upgrade.UpgradePluginExecutionContext;
 import org.exoplatform.commons.upgrade.UpgradeProductPlugin;
@@ -113,6 +118,8 @@ public class NewsArticlesUpgrade extends UpgradeProductPlugin {
   private SettingService           settingService;
 
   private AttachmentStorage        attachmentStorage;
+  
+  private EntityManagerService entityManagerService;
 
   private int                      migratedNewsArticlesCount = 0;
 
@@ -143,7 +150,8 @@ public class NewsArticlesUpgrade extends UpgradeProductPlugin {
                              IdentityManager identityManager,
                              IndexingService indexingService,
                              AttachmentStorage attachmentStorage,
-                             SettingService settingService) {
+                             SettingService settingService,
+                             EntityManagerService entityManagerService) {
     super(initParams);
     this.repositoryService = repositoryService;
     this.sessionProviderService = sessionProviderService;
@@ -157,6 +165,7 @@ public class NewsArticlesUpgrade extends UpgradeProductPlugin {
     this.indexingService = indexingService;
     this.settingService = settingService;
     this.attachmentStorage = attachmentStorage;
+    this.entityManagerService = entityManagerService;
   }
 
   @Override
@@ -298,8 +307,6 @@ public class NewsArticlesUpgrade extends UpgradeProductPlugin {
           newsArticleNode = session.getNodeByUUID(newsArticleNodeUUID);
           setArticleIllustration(pageVersion.getParent(), article.getSpaceId(), newsArticleNode, "notePage");
           setArticleAttachments(pageVersion.getId(), newsArticleNode);
-          /* upgrade news id for news targets and favorite metadatata items */
-          setArticleMetadatasItems(article.getId(), newsArticleNodeUUID);
           if (getStringProperty(newsArticleNode, "publication:currentState").equals("published")) {
             setArticleActivities(article, newsArticleNode);
             setArticleViews(article, newsArticleNode);
@@ -310,6 +317,8 @@ public class NewsArticlesUpgrade extends UpgradeProductPlugin {
           }
           // set the update and the created date
           setArticleCreateAndUpdateDate(article.getId(), article.getSpaceId(), newsArticleNode);
+          /* upgrade news id for news targets and favorite metadatata items */
+          setArticleMetadatasItems(article.getId(), newsArticleNodeUUID);
         } else if (getStringProperty(newsArticleNode, "publication:currentState").equals("draft")) {
 
           // drafts of not existing articles
@@ -362,9 +371,6 @@ public class NewsArticlesUpgrade extends UpgradeProductPlugin {
             newsArticleNode = session.getNodeByUUID(newsArticleNodeUUID);
             setArticleIllustration(pageVersion.getParent(), article.getSpaceId(), publishedNode, "notePage");
             setArticleAttachments(pageVersion.getId(), publishedNode);
-            // upgrade news id for news targets and favorite metadatata items
-            setArticleMetadatasItems(article.getId(), newsArticleNodeUUID);
-
             setArticleActivities(article, publishedNode);
             setArticleViews(article, newsArticleNode);
 
@@ -391,7 +397,17 @@ public class NewsArticlesUpgrade extends UpgradeProductPlugin {
               newsArticleNode = session.getNodeByUUID(newsArticleNodeUUID);
               setArticleIllustration(draftPage, draftForExistingArticle.getSpaceId(), newsArticleNode, "noteDraftPage");
             }
+            // upgrade news id for news targets and favorite metadatata items
+            setArticleMetadatasItems(article.getId(), newsArticleNodeUUID);
           }
+        }
+        if (!session.isLive()) {
+          session = sessionProvider.getSession(
+                                               repositoryService.getCurrentRepository()
+                                                                .getConfiguration()
+                                                                .getDefaultWorkspaceName(),
+                                               repositoryService.getCurrentRepository());
+          newsArticleNode = session.getNodeByUUID(newsArticleNodeUUID);
         }
         newsArticleNode.remove();
         session.save();
@@ -639,13 +655,12 @@ public class NewsArticlesUpgrade extends UpgradeProductPlugin {
     }
   }
 
+  @ExoTransactional
   private void setArticleMetadatasItems(String targetId, String sourceId) throws RepositoryException {
-    MetadataObject metadataObject = new MetadataObject(NewsUtils.NEWS_METADATA_OBJECT_TYPE, sourceId);
-    List<MetadataItem> metadataItems = metadataService.getMetadataItemsByObject(metadataObject);
-    for (MetadataItem metadataItem : metadataItems) {
-      metadataItem.setObjectId(targetId);
-      metadataService.updateMetadataItem(metadataItem, metadataItem.getCreatorId());
-    }
+    EntityManager entityManager = entityManagerService.getEntityManager();
+    String sqlStatement = "UPDATE SOC_METADATA_ITEMS SET OBJECT_ID = '" + targetId + "' WHERE OBJECT_ID = '" + sourceId + "';";
+    jakarta.persistence.Query query = entityManager.createNativeQuery(sqlStatement);
+    query.executeUpdate();
   }
 
   private void setArticleCreateAndUpdateDate(String articleId, String spaceId, Node newsNode) throws Exception {

--- a/data-upgrade-news/src/test/java/org/exoplatform/news/upgrade/jcr/NewsArticlesUpgradeTest.java
+++ b/data-upgrade-news/src/test/java/org/exoplatform/news/upgrade/jcr/NewsArticlesUpgradeTest.java
@@ -56,6 +56,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 import org.exoplatform.commons.api.settings.SettingService;
 import org.exoplatform.commons.api.settings.SettingValue;
 import org.exoplatform.commons.file.services.FileService;
+import org.exoplatform.commons.persistence.impl.EntityManagerService;
 import org.exoplatform.commons.search.index.IndexingService;
 import org.exoplatform.commons.upgrade.UpgradePluginExecutionContext;
 import org.exoplatform.commons.utils.CommonsUtils;
@@ -84,6 +85,7 @@ import org.exoplatform.wiki.service.NoteService;
 
 import io.meeds.news.model.News;
 import io.meeds.news.service.NewsService;
+import jakarta.persistence.EntityManager;
 
 @RunWith(MockitoJUnitRunner.class)
 public class NewsArticlesUpgradeTest {
@@ -134,6 +136,9 @@ public class NewsArticlesUpgradeTest {
   @Mock
   private AttachmentStorage                       attachmentStorage;
 
+  @Mock
+  private EntityManagerService                    entityManagerService;
+
   private NewsArticlesUpgrade                     newsArticlesUpgrade;
 
   @AfterClass
@@ -162,7 +167,8 @@ public class NewsArticlesUpgradeTest {
                                                   identityManager,
                                                   indexingService,
                                                   attachmentStorage,
-                                                  settingService);
+                                                  settingService,
+                                                  entityManagerService);
   }
 
   @Test
@@ -301,6 +307,10 @@ public class NewsArticlesUpgradeTest {
     News news2 = (News) method.invoke(newsArticlesUpgrade, node2, null);
     when(newsService.createNewsArticlePage(news1, "")).thenReturn(article);
     when(newsService.createNewsArticlePage(news2, "")).thenReturn(article);
+    EntityManager entityManager = mock(EntityManager.class);
+    jakarta.persistence.Query updateMetadataItemsQuery = mock(jakarta.persistence.Query.class);
+    when(entityManagerService.getEntityManager()).thenReturn(entityManager);
+    when(entityManager.createNativeQuery(anyString())).thenReturn(updateMetadataItemsQuery);
     // Run the processUpgrade method
     newsArticlesUpgrade.processUpgrade("1.0", "2.0");
 

--- a/data-upgrade-news/src/test/java/org/exoplatform/news/upgrade/jcr/NewsArticlesUpgradeTest.java
+++ b/data-upgrade-news/src/test/java/org/exoplatform/news/upgrade/jcr/NewsArticlesUpgradeTest.java
@@ -17,6 +17,7 @@
 package org.exoplatform.news.upgrade.jcr;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -317,7 +318,7 @@ public class NewsArticlesUpgradeTest {
     verify(newsService, times(2)).createNewsArticlePage(any(News.class), anyString());
     verify(noteService, times(2)).getPublishedVersionByPageIdAndLang(anyLong(), nullable(String.class));
     verify(metadataService, times(6)).getMetadataItemsByMetadataAndObject(any(), any(MetadataObject.class));
-    verify(metadataService, times(6)).updateMetadataItem(any(), anyLong());
+    verify(metadataService, times(6)).updateMetadataItem(any(), anyLong(), anyBoolean());
     verify(activityManager, times(1)).getActivity(any());
     verify(activityManager, times(1)).updateActivity(any(ExoSocialActivity.class), eq(false));
   }


### PR DESCRIPTION

Prior to this change, we face some perf and jcr session timeout issues with the news article UP when migrating from 6.5.5 to 7.0.0-M56. This is related to jcr session logout caused by a big execution time of setMetadataItems for some articles related to spaces with a big number of members (~7000) and having a big number of unread metadataItems (~7000). After this commit, we will fix these problems by:
-/ Enhancing the execution time of such cases by using an sql query for setMetadataItems which set all metadataItems with only one sql query instead of using the metadataService.updateMetadataItem method in the loop of metadataItems. 
-/ Recreating the jcr session after this setMetadataItems treatment in order to avoid the jcr session timeout if the execution time still big for some other cases.