### PR TITLE
Fix: Fix upgrade issues of some articles from 6.5.5 to 7.0 - EXO-78125

### DIFF
--- a/data-upgrade-news/pom.xml
+++ b/data-upgrade-news/pom.xml
@@ -24,7 +24,7 @@
   <name>eXo Add-on:: Data Upgrade Add-on - NEWS</name>
 
   <properties>
-    <exo.test.coverage.ratio>0.63</exo.test.coverage.ratio>
+    <exo.test.coverage.ratio>0.68</exo.test.coverage.ratio>
   </properties>
 
   <dependencies>

--- a/data-upgrade-news/src/main/java/org/exoplatform/news/upgrade/ContentDraftArticlesUpgrade.java
+++ b/data-upgrade-news/src/main/java/org/exoplatform/news/upgrade/ContentDraftArticlesUpgrade.java
@@ -1,0 +1,324 @@
+/*
+ * Copyright (C) 2025 eXo Platform SAS.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.exoplatform.news.upgrade;
+
+import java.util.Arrays;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import javax.jcr.RepositoryException;
+
+import org.apache.commons.collections4.ListUtils;
+
+import org.exoplatform.commons.api.persistence.ExoTransactional;
+import org.exoplatform.commons.api.settings.SettingService;
+import org.exoplatform.commons.api.settings.SettingValue;
+import org.exoplatform.commons.api.settings.data.Context;
+import org.exoplatform.commons.api.settings.data.Scope;
+import org.exoplatform.commons.persistence.impl.EntityManagerService;
+import org.exoplatform.commons.upgrade.UpgradePluginExecutionContext;
+import org.exoplatform.commons.upgrade.UpgradeProductPlugin;
+import org.exoplatform.commons.utils.PropertyManager;
+import org.exoplatform.container.xml.InitParams;
+import org.exoplatform.services.log.ExoLogger;
+import org.exoplatform.services.log.Log;
+import org.exoplatform.social.core.activity.model.ExoSocialActivity;
+import org.exoplatform.social.core.manager.ActivityManager;
+import org.exoplatform.social.core.manager.IdentityManager;
+import org.exoplatform.social.core.space.model.Space;
+import org.exoplatform.social.core.space.spi.SpaceService;
+import org.exoplatform.social.metadata.MetadataService;
+import org.exoplatform.social.metadata.model.MetadataItem;
+import org.exoplatform.social.metadata.model.MetadataType;
+import org.exoplatform.wiki.model.Page;
+import org.exoplatform.wiki.service.NoteService;
+
+import io.meeds.news.model.News;
+import io.meeds.news.model.NewsPageObject;
+import io.meeds.news.service.NewsService;
+import io.meeds.news.service.impl.NewsServiceImpl;
+import io.meeds.news.utils.NewsUtils;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.Query;
+
+public class ContentDraftArticlesUpgrade extends UpgradeProductPlugin {
+
+  private static final Log         LOG                                         =
+                                       ExoLogger.getLogger(ContentDraftArticlesUpgrade.class.getName());
+
+  private ActivityManager          activityManager;
+
+  private IdentityManager          identityManager;
+
+  private NoteService              noteService;
+
+  private NewsService              newsService;
+
+  private SpaceService             spaceService;
+
+  private SettingService           settingService;
+
+  private MetadataService          metadataService;
+
+  private EntityManagerService     entityManagerService;
+
+  private int                      migratedDraftArticlesCount                  = 0;
+
+  public static final MetadataType NEWS_METADATA_TYPE                          = new MetadataType(1000, "news");
+
+  public static final String       NEWS_METADATA_NAME                          = "news";
+
+  private static final String      PLUGIN_NAME                                 = "ContentDraftArticlesUpgrade";
+
+  private static final String      PLUGIN_EXECUTED_KEY                         = "contentDraftArticlesUpgradeExecuted";
+
+  private static final String      CONTENT_INCONSISTENT_DRAFT_ARTICLES_UPGRADE = "content.inconsistent.draft.articles.upgrade";
+
+  private String                   contentInconsistentDraftArticlesUpgrade;
+
+  private boolean                  upgradeFailed                               = false;
+
+  public ContentDraftArticlesUpgrade(InitParams initParams,
+                                     ActivityManager activityManager,
+                                     IdentityManager identityManager,
+                                     NoteService noteService,
+                                     NewsService newsService,
+                                     SpaceService spaceService,
+                                     SettingService settingService,
+                                     MetadataService metadataService,
+                                     EntityManagerService entityManagerService) {
+    super(initParams);
+    if (initParams.containsKey(CONTENT_INCONSISTENT_DRAFT_ARTICLES_UPGRADE)) {
+      contentInconsistentDraftArticlesUpgrade = initParams.getValueParam(CONTENT_INCONSISTENT_DRAFT_ARTICLES_UPGRADE).getValue();
+    }
+    this.activityManager = activityManager;
+    this.identityManager = identityManager;
+    this.noteService = noteService;
+    this.newsService = newsService;
+    this.spaceService = spaceService;
+    this.settingService = settingService;
+    this.metadataService = metadataService;
+    this.entityManagerService = entityManagerService;
+  }
+
+  @Override
+  public void processUpgrade(String oldVersion, String newVersion) {
+    long startupTime = System.currentTimeMillis();
+    LOG.info("Start upgrade of draft articles");
+    int notMigratedDraftArticlesCount = 0;
+    int ignoredDraftArticlesCount = 0;
+    int processedDraftArticlesCount = 0;
+    long totalDraftArticlesCount = 0;
+    try {
+      List<String> draftArticles = Arrays.asList(contentInconsistentDraftArticlesUpgrade.split(";"));
+      totalDraftArticlesCount = draftArticles.size();
+      LOG.info("Total number of draft articles to be migrated: {}", totalDraftArticlesCount);
+      for (List<String> draftArticlesChunk : ListUtils.partition(draftArticles, 10)) {
+        Map<String, Integer> draftArticlesCountByTransaction = manageDraftArticles(draftArticlesChunk);
+        int processedDraftArticlesCountByTransaction = draftArticlesChunk.size();
+        processedDraftArticlesCount += processedDraftArticlesCountByTransaction;
+        migratedDraftArticlesCount += processedDraftArticlesCountByTransaction
+            - draftArticlesCountByTransaction.get("notMigratedDraftArticlesCountByTransaction")
+            - draftArticlesCountByTransaction.get("ignoredDraftArticlesCountByTransaction");
+        notMigratedDraftArticlesCount += draftArticlesCountByTransaction.get("notMigratedDraftArticlesCountByTransaction");
+        ignoredDraftArticlesCount += draftArticlesCountByTransaction.get("ignoredDraftArticlesCountByTransaction");
+        LOG.info("Draft articles migration progress: processed={}/{} succeeded={} ignored={} error={}",
+                 processedDraftArticlesCount,
+                 totalDraftArticlesCount,
+                 migratedDraftArticlesCount,
+                 ignoredDraftArticlesCount,
+                 notMigratedDraftArticlesCount);
+      }
+    } catch (Exception e) {
+      LOG.error("An error occurred when upgrading draft articles:", e);
+    }
+    if (totalDraftArticlesCount == migratedDraftArticlesCount) {
+      LOG.info("End draft articles migration successful migration: total={} succeeded={} ignored={} error={}. It tooks {} ms.",
+               totalDraftArticlesCount,
+               migratedDraftArticlesCount,
+               ignoredDraftArticlesCount,
+               notMigratedDraftArticlesCount,
+               (System.currentTimeMillis() - startupTime));
+    } else {
+      LOG.warn("End draft articles migration with some errors: total={} succeeded={} ignored={} error={}. It tooks {} ms."
+          + " The not migrated draft articles will be processed again next startup.",
+               totalDraftArticlesCount,
+               migratedDraftArticlesCount,
+               ignoredDraftArticlesCount,
+               notMigratedDraftArticlesCount,
+               (System.currentTimeMillis() - startupTime));
+      this.upgradeFailed = true;
+      throw new IllegalStateException("Some draft articles wasn't executed successfully. It will be re-attempted next startup");
+    }
+  }
+
+  @Override
+  public void afterUpgrade() {
+    if (!upgradeFailed) {
+      settingService.set(Context.GLOBAL.id(PLUGIN_NAME),
+                         Scope.APPLICATION.id(PLUGIN_NAME),
+                         PLUGIN_EXECUTED_KEY,
+                         SettingValue.create(true));
+    }
+  }
+
+  @Override
+  public boolean shouldProceedToUpgrade(String newVersion,
+                                        String previousGroupVersion,
+                                        UpgradePluginExecutionContext upgradePluginExecutionContext) {
+    SettingValue<?> settingValue = settingService.get(Context.GLOBAL.id(PLUGIN_NAME),
+                                                      Scope.APPLICATION.id(PLUGIN_NAME),
+                                                      PLUGIN_EXECUTED_KEY);
+    boolean shouldUpgrade = super.shouldProceedToUpgrade(newVersion, previousGroupVersion, upgradePluginExecutionContext);
+    if (!shouldUpgrade && settingValue == null) {
+      settingService.set(Context.GLOBAL.id(PLUGIN_NAME),
+                         Scope.APPLICATION.id(PLUGIN_NAME),
+                         PLUGIN_EXECUTED_KEY,
+                         SettingValue.create(true));
+    }
+    return shouldUpgrade;
+  }
+
+  @Override
+  public boolean isEnabled() {
+    String isEnabledProperty = PropertyManager.getProperty(UPGRADE_PLUGIN_ENABLE.replace("{$0}", getName()));
+    return isEnabledProperty != null && isEnabledProperty.equals("true");
+  }
+
+  public Map<String, Integer> manageDraftArticles(List<String> draftArticles) {
+    int notMigratedDraftArticlesCountByTransaction = 0;
+    int ignoredDraftArticlesCountByTransaction = 0;
+    Map<String, Integer> draftArticlesCountByTransaction = new HashMap<String, Integer>();
+    for (String draftArticle : draftArticles) {
+      String draftArticleId = draftArticle.split(",")[0];
+      String articleActivityId = draftArticle.split(",")[1];
+      try {
+        ExoSocialActivity articleActivity = activityManager.getActivity(articleActivityId);
+        String poster = identityManager.getIdentity(Long.parseLong(articleActivity.getPosterId())).getRemoteId();
+        Page draftArticlePage = noteService.getDraftNoteById(draftArticleId, poster);
+        if (draftArticlePage != null) {
+          News news = convertdraftArticlePageToNewEntity(draftArticlePage);
+          News article = newsService.createNewsArticlePage(news, news.getAuthor());
+          String oldNewsId = setArticleActivities(article.getId(), news.getSpaceId(), articleActivity);
+          setArticleMetadatasItems(article.getId(), oldNewsId);
+          setArticleCreateAndUpdateDate(article.getId(), news.getSpaceId(), draftArticlePage);
+          LOG.info("Success migrating draft article with id '{}' and activity '{}'", draftArticleId, articleActivityId);
+        } else {
+          ignoredDraftArticlesCountByTransaction++;
+          LOG.info("Ignore migrating not found draft article with id '{}' and activity '{}'. Continue to migrate other items",
+                   draftArticleId,
+                   articleActivityId);
+        }
+
+      } catch (Exception e) {
+        notMigratedDraftArticlesCountByTransaction++;
+        LOG.warn("Error migrating draft article with id '{}'. Continue to migrate other items", draftArticleId, e);
+      }
+    }
+    draftArticlesCountByTransaction.put("notMigratedDraftArticlesCountByTransaction", notMigratedDraftArticlesCountByTransaction);
+    draftArticlesCountByTransaction.put("ignoredDraftArticlesCountByTransaction", ignoredDraftArticlesCountByTransaction);
+    return draftArticlesCountByTransaction;
+  }
+
+  private News convertdraftArticlePageToNewEntity(Page draftArticlePage) throws Exception {
+    News news = new News();
+    news.setId(draftArticlePage.getId());
+    news.setTitle(draftArticlePage.getTitle());
+    news.setName(news.getTitle());
+    news.setProperties(draftArticlePage.getProperties());
+    news.setBody(draftArticlePage.getContent());
+    news.setAuthor(draftArticlePage.getAuthor());
+    news.setDraftUpdaterUserName(draftArticlePage.getLastUpdater());
+    Space space = spaceService.getSpaceByGroupId(draftArticlePage.getWikiOwner());
+    news.setSpaceId(space.getId());
+    news.setPublicationState("posted");
+    news.setPublished(false);
+    news.setActivityPosted(true);
+    news.setCreationDate(draftArticlePage.getCreatedDate());
+    news.setUpdateDate(draftArticlePage.getUpdatedDate());
+    return news;
+  }
+
+  private String setArticleActivities(String articleId, String articleSpaceId, ExoSocialActivity articleActivity) {
+    NewsPageObject articleMetaDataObject = new NewsPageObject(NewsServiceImpl.NEWS_METADATA_PAGE_OBJECT_TYPE,
+                                                              articleId,
+                                                              null,
+                                                              Long.parseLong(articleSpaceId));
+    MetadataItem articleMetadataItem = metadataService
+                                                      .getMetadataItemsByMetadataAndObject(NewsServiceImpl.NEWS_METADATA_KEY,
+                                                                                           articleMetaDataObject)
+                                                      .stream()
+                                                      .findFirst()
+                                                      .orElse(null);
+    String articleActivities = articleSpaceId + ":" + articleActivity.getId();
+    if (articleMetadataItem != null) {
+      Map<String, String> articleMetadataItemProperties = articleMetadataItem.getProperties();
+      if (articleMetadataItemProperties == null) {
+        articleMetadataItemProperties = new HashMap<>();
+      }
+      articleMetadataItemProperties.put("activities", articleActivities);
+      articleMetadataItem.setProperties(articleMetadataItemProperties);
+      metadataService.updateMetadataItem(articleMetadataItem, articleMetadataItem.getCreatorId(), false);
+    }
+    Map<String, String> templateParams = articleActivity.getTemplateParams() == null ? new HashMap<>()
+                                                                                     : articleActivity.getTemplateParams();
+    String oldNewsId = templateParams.get("newsId");
+    templateParams.put("newsId", articleId);
+    articleActivity.setTemplateParams(templateParams);
+    articleActivity.setMetadataObjectId(articleId);
+    articleActivity.setMetadataObjectType(NewsUtils.NEWS_METADATA_OBJECT_TYPE);
+    activityManager.updateActivity(articleActivity, false);
+    return oldNewsId;
+  }
+
+  @ExoTransactional
+  private void setArticleMetadatasItems(String targetId, String sourceId) throws RepositoryException {
+    EntityManager entityManager = entityManagerService.getEntityManager();
+    String sqlStatement = "UPDATE SOC_METADATA_ITEMS SET OBJECT_ID = '" + targetId + "' WHERE OBJECT_ID = '" + sourceId + "';";
+    Query query = entityManager.createNativeQuery(sqlStatement);
+    query.executeUpdate();
+  }
+
+  private void setArticleCreateAndUpdateDate(String articleId, String articleSpaceId, Page draftArticlePage) throws Exception {
+    Page articlePage = noteService.getNoteById(articleId);
+    if (articlePage != null) {
+      Date createdDate = draftArticlePage.getCreatedDate();
+      Date updatedDate = draftArticlePage.getUpdatedDate();
+      MetadataItem articleMetaDataItem =
+                                       metadataService.getMetadataItemsByMetadataAndObject(NewsServiceImpl.NEWS_METADATA_KEY,
+                                                                                           new NewsPageObject(NewsServiceImpl.NEWS_METADATA_PAGE_OBJECT_TYPE,
+                                                                                                              articleId,
+                                                                                                              null,
+                                                                                                              Long.parseLong(articleSpaceId)))
+                                                      .stream()
+                                                      .findFirst()
+                                                      .orElse(null);
+      if (updatedDate != null) {
+        articlePage.setUpdatedDate(updatedDate);
+        articleMetaDataItem.setUpdatedDate(updatedDate.getTime());
+      }
+      if (createdDate != null) {
+        articlePage.setCreatedDate(createdDate);
+        articleMetaDataItem.setCreatedDate(createdDate.getTime());
+      }
+      noteService.updateNote(articlePage);
+      metadataService.updateMetadataItem(articleMetaDataItem, articleMetaDataItem.getCreatorId(), false);
+    }
+  }
+}

--- a/data-upgrade-news/src/main/java/org/exoplatform/news/upgrade/jcr/NewsArticlesUpgrade.java
+++ b/data-upgrade-news/src/main/java/org/exoplatform/news/upgrade/jcr/NewsArticlesUpgrade.java
@@ -36,11 +36,7 @@ import javax.jcr.Value;
 import javax.jcr.query.Query;
 import javax.jcr.query.QueryManager;
 
-import io.meeds.notes.model.NotePageProperties;
-import jakarta.persistence.EntityManager;
-
 import org.apache.commons.collections4.ListUtils;
-
 import org.apache.commons.collections4.MapUtils;
 import org.apache.commons.lang3.StringUtils;
 
@@ -81,13 +77,15 @@ import org.exoplatform.wiki.model.DraftPage;
 import org.exoplatform.wiki.model.Page;
 import org.exoplatform.wiki.model.PageVersion;
 import org.exoplatform.wiki.service.NoteService;
+import org.exoplatform.wiki.utils.Utils;
 
 import io.meeds.news.model.News;
 import io.meeds.news.model.NewsPageObject;
 import io.meeds.news.search.NewsIndexingServiceConnector;
 import io.meeds.news.service.NewsService;
 import io.meeds.news.utils.NewsUtils;
-import org.exoplatform.wiki.utils.Utils;
+import io.meeds.notes.model.NotePageProperties;
+import jakarta.persistence.EntityManager;
 
 public class NewsArticlesUpgrade extends UpgradeProductPlugin {
 
@@ -116,8 +114,8 @@ public class NewsArticlesUpgrade extends UpgradeProductPlugin {
   private SettingService           settingService;
 
   private AttachmentStorage        attachmentStorage;
-  
-  private EntityManagerService entityManagerService;
+
+  private EntityManagerService     entityManagerService;
 
   private int                      migratedNewsArticlesCount = 0;
 
@@ -280,7 +278,7 @@ public class NewsArticlesUpgrade extends UpgradeProductPlugin {
                                                      repositoryService.getCurrentRepository());
         Node newsArticleNode = session.getNodeByUUID(newsArticleNodeUUID);
         indexingService.unindex(NewsIndexingServiceConnector.TYPE, newsArticleNodeUUID);
-        News news = convertNewsNodeToNewEntity(newsArticleNode, null);
+        News news = convertNewsNodeToNewsEntity(newsArticleNode, null);
         NotePageProperties properties = news.getProperties();
         LOG.info("Migrating news article with id '{}' and title '{}'", newsArticleNodeUUID, news.getTitle());
         Space space = spaceService.getSpaceById(news.getSpaceId());
@@ -349,7 +347,7 @@ public class NewsArticlesUpgrade extends UpgradeProductPlugin {
             String versionNodeUUID = newsArticleNode.getProperty(AuthoringPublicationConstant.LIVE_REVISION_PROP).getString();
             Node versionNode = newsArticleNode.getVersionHistory().getSession().getNodeByUUID(versionNodeUUID);
             Node publishedNode = versionNode.getNode("jcr:frozenNode");
-            News publishedNews = convertNewsNodeToNewEntity(newsArticleNode, publishedNode);
+            News publishedNews = convertNewsNodeToNewsEntity(newsArticleNode, publishedNode);
             article = newsService.createNewsArticlePage(publishedNews, publishedNews.getAuthor());
             properties = publishedNews.getProperties();
             properties.setNoteId(Long.parseLong(article.getId()));
@@ -385,8 +383,7 @@ public class NewsArticlesUpgrade extends UpgradeProductPlugin {
                                                                                     publishedPage,
                                                                                     news.getCreationDate().getTime(),
                                                                                     space);
-              DraftPage draftPage = noteService.getDraftNoteById(draftForExistingArticle.getId(),
-                                                                 news.getDraftUpdaterUserName());
+              DraftPage draftPage = noteService.getDraftNoteById(draftForExistingArticle.getId(), news.getDraftUpdaterUserName());
               session = sessionProvider.getSession(
                                                    repositoryService.getCurrentRepository()
                                                                     .getConfiguration()
@@ -422,10 +419,11 @@ public class NewsArticlesUpgrade extends UpgradeProductPlugin {
           }
         } catch (Exception exception) {
           if (article != null) {
-            LOG.warn("The deletion of the not migrated news article with id '{}' is not well completed, to be verified and deleted manually.", article.getId());
-          }
-          else if (draftArticle != null) {
-            LOG.warn("The deletion of the not migrated news draft article with id '{}' is not well completed, to be verified and deleted manually.", draftArticle.getId());
+            LOG.warn("The deletion of the not migrated news article with id '{}' is not well completed, to be verified and deleted manually.",
+                     article.getId());
+          } else if (draftArticle != null) {
+            LOG.warn("The deletion of the not migrated news draft article with id '{}' is not well completed, to be verified and deleted manually.",
+                     draftArticle.getId());
           }
         }
       }
@@ -433,7 +431,7 @@ public class NewsArticlesUpgrade extends UpgradeProductPlugin {
     return notMigratedNewsArticlesCountByTransaction;
   }
 
-  private News convertNewsNodeToNewEntity(Node newsNode, Node newsVersionNode) throws Exception {
+  private News convertNewsNodeToNewsEntity(Node newsNode, Node newsVersionNode) throws Exception {
     News news = new News();
     String portalOwner = CommonsUtils.getCurrentPortalOwner();
     news.setTitle(getStringProperty(newsVersionNode != null ? newsVersionNode : newsNode, "exo:title"));
@@ -544,7 +542,11 @@ public class NewsArticlesUpgrade extends UpgradeProductPlugin {
           articleMetadataItem.setProperties(articleMetadataItemProperties);
           metadataService.updateMetadataItem(articleMetadataItem, creatorId, false);
         } else {
-          metadataService.createMetadataItem(articleMetaDataObject, NOTES_METADATA_KEY, articleMetadataItemProperties, creatorId, false);
+          metadataService.createMetadataItem(articleMetaDataObject,
+                                             NOTES_METADATA_KEY,
+                                             articleMetadataItemProperties,
+                                             creatorId,
+                                             false);
         }
       }
     }
@@ -664,27 +666,27 @@ public class NewsArticlesUpgrade extends UpgradeProductPlugin {
   private void setArticleCreateAndUpdateDate(String articleId, String spaceId, Node newsNode) throws Exception {
     Page articlePage = noteService.getNoteById(articleId);
     if (articlePage != null) {
-      Date createDate = getDateProperty(newsNode, "exo:dateCreated");
-      Date updateDate = getDateProperty(newsNode, "exo:dateModified");
-      MetadataItem articleMetaData =
-                                   metadataService.getMetadataItemsByMetadataAndObject(NEWS_METADATA_KEY,
-                                                                                       new NewsPageObject("newsPage",
-                                                                                                          articleId,
-                                                                                                          null,
-                                                                                                          Long.parseLong(spaceId)))
-                                                  .stream()
-                                                  .findFirst()
-                                                  .orElse(null);
-      if (updateDate != null) {
-        articlePage.setUpdatedDate(updateDate);
-        articleMetaData.setUpdatedDate(updateDate.getTime());
+      Date createdDate = getDateProperty(newsNode, "exo:dateCreated");
+      Date updatedDate = getDateProperty(newsNode, "exo:dateModified");
+      MetadataItem articleMetaDataItem =
+                                       metadataService.getMetadataItemsByMetadataAndObject(NEWS_METADATA_KEY,
+                                                                                           new NewsPageObject("newsPage",
+                                                                                                              articleId,
+                                                                                                              null,
+                                                                                                              Long.parseLong(spaceId)))
+                                                      .stream()
+                                                      .findFirst()
+                                                      .orElse(null);
+      if (updatedDate != null) {
+        articlePage.setUpdatedDate(updatedDate);
+        articleMetaDataItem.setUpdatedDate(updatedDate.getTime());
       }
-      if (createDate != null) {
-        articlePage.setCreatedDate(createDate);
-        articleMetaData.setCreatedDate(createDate.getTime());
+      if (createdDate != null) {
+        articlePage.setCreatedDate(createdDate);
+        articleMetaDataItem.setCreatedDate(createdDate.getTime());
       }
       noteService.updateNote(articlePage);
-      metadataService.updateMetadataItem(articleMetaData, articleMetaData.getCreatorId(), false);
+      metadataService.updateMetadataItem(articleMetaDataItem, articleMetaDataItem.getCreatorId(), false);
     }
   }
 

--- a/data-upgrade-news/src/main/resources/conf/portal/configuration.xml
+++ b/data-upgrade-news/src/main/resources/conf/portal/configuration.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Copyright (C) 2024 eXo Platform SAS. This program is free software: 
+<!-- Copyright (C) 2025 eXo Platform SAS. This program is free software: 
   you can redistribute it and/or modify it under the terms of the GNU Affero 
   General Public License as published by the Free Software Foundation, either 
   version 3 of the License, or (at your option) any later version. This program 
@@ -145,6 +145,45 @@
           <name>plugin.upgrade.target.version</name>
           <description>Target version of the plugin</description>
           <value>7.0.0</value>
+        </value-param>
+      </init-params>
+    </component-plugin>
+    
+    <component-plugin profiles="content">
+      <name>ContentDraftArticlesUpgrade</name>
+      <set-method>addUpgradePlugin</set-method>
+      <type>org.exoplatform.news.upgrade.ContentDraftArticlesUpgrade</type>
+      <description>Update draft articles</description>
+      <init-params>
+        <value-param>
+          <name>product.group.id</name>
+          <description>The groupId of the product</description>
+          <value>org.exoplatform.platform</value>
+        </value-param>
+        <value-param>
+          <name>plugin.execution.order</name>
+          <description>The plugin execution order</description>
+          <value>2</value>
+        </value-param>
+        <value-param>
+          <name>plugin.upgrade.execute.once</name>
+          <description>Execute this upgrade plugin only once</description>
+          <value>false</value>
+        </value-param>
+        <value-param>
+          <name>plugin.upgrade.async.execution</name>
+          <description>The plugin will be executed in an asynchronous mode</description>
+          <value>true</value>
+        </value-param>
+        <value-param>
+          <name>plugin.upgrade.target.version</name>
+          <description>Target version of the plugin</description>
+          <value>7.0.1</value>
+        </value-param>
+        <value-param>
+          <name>content.inconsistent.draft.articles.upgrade</name>
+          <description>Content inconsistent draft articles upgrade</description>
+          <value>${content.inconsistent.draft.articles.upgrade:}</value>
         </value-param>
       </init-params>
     </component-plugin>

--- a/data-upgrade-news/src/test/java/org/exoplatform/news/upgrade/ContentDraftArticlesUpgradeTest.java
+++ b/data-upgrade-news/src/test/java/org/exoplatform/news/upgrade/ContentDraftArticlesUpgradeTest.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright (C) 2025 eXo Platform SAS.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.exoplatform.news.upgrade;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.nullable;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import org.exoplatform.commons.api.settings.SettingService;
+import org.exoplatform.commons.api.settings.SettingValue;
+import org.exoplatform.commons.persistence.impl.EntityManagerService;
+import org.exoplatform.commons.upgrade.UpgradePluginExecutionContext;
+import org.exoplatform.container.xml.InitParams;
+import org.exoplatform.container.xml.ValueParam;
+import org.exoplatform.social.core.activity.model.ExoSocialActivity;
+import org.exoplatform.social.core.identity.model.Identity;
+import org.exoplatform.social.core.manager.ActivityManager;
+import org.exoplatform.social.core.manager.IdentityManager;
+import org.exoplatform.social.core.space.model.Space;
+import org.exoplatform.social.core.space.spi.SpaceService;
+import org.exoplatform.social.metadata.MetadataService;
+import org.exoplatform.social.metadata.model.MetadataItem;
+import org.exoplatform.social.metadata.model.MetadataKey;
+import org.exoplatform.social.metadata.model.MetadataObject;
+import org.exoplatform.wiki.model.DraftPage;
+import org.exoplatform.wiki.model.Page;
+import org.exoplatform.wiki.service.NoteService;
+
+import io.meeds.news.model.News;
+import io.meeds.news.service.NewsService;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.Query;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ContentDraftArticlesUpgradeTest {
+
+  @Mock
+  private ActivityManager             activityManager;
+
+  @Mock
+  private IdentityManager             identityManager;
+
+  @Mock
+  private NoteService                 noteService;
+
+  @Mock
+  private NewsService                 newsService;
+
+  @Mock
+  private SpaceService                spaceService;
+
+  @Mock
+  private SettingService              settingService;
+
+  @Mock
+  private MetadataService             metadataService;
+
+  @Mock
+  private EntityManagerService        entityManagerService;
+
+  private ContentDraftArticlesUpgrade contentDraftArticlesUpgrade;
+
+  @Before
+  public void setUp() {
+    InitParams initParams = new InitParams();
+
+    ValueParam valueParam1 = new ValueParam();
+    valueParam1.setName("product.group.id");
+    valueParam1.setValue("org.exoplatform.platform");
+    ValueParam valueParam2 = new ValueParam();
+    valueParam2.setName("content.inconsistent.draft.articles.upgrade");
+    valueParam2.setValue("1,1;2,2");
+    initParams.addParameter(valueParam1);
+    initParams.addParameter(valueParam2);
+    contentDraftArticlesUpgrade = new ContentDraftArticlesUpgrade(initParams,
+                                                                  activityManager,
+                                                                  identityManager,
+                                                                  noteService,
+                                                                  newsService,
+                                                                  spaceService,
+                                                                  settingService,
+                                                                  metadataService,
+                                                                  entityManagerService);
+  }
+
+  @Test
+  public void testProcessUpgrade() throws Exception {
+
+    ExoSocialActivity articleActivity = mock(ExoSocialActivity.class);
+    when(articleActivity.getPosterId()).thenReturn("1");
+    when(activityManager.getActivity(anyString())).thenReturn(articleActivity);
+    Identity identity = mock(Identity.class);
+    when(identity.getRemoteId()).thenReturn("root");
+    when(identityManager.getIdentity(anyLong())).thenReturn(identity);
+    DraftPage draftPage = mock(DraftPage.class);
+    when(draftPage.getWikiOwner()).thenReturn("/spaces/test");
+    when(noteService.getDraftNoteById(anyString(), anyString())).thenReturn(draftPage);
+    Space space = mock(Space.class);
+    when(spaceService.getSpaceByGroupId(anyString())).thenReturn(space);
+    when(space.getId()).thenReturn("1");
+    News article = mock(News.class);
+    when(newsService.createNewsArticlePage(any(News.class), nullable(String.class))).thenReturn(article);
+    List<MetadataItem> articleMetadataItems = Arrays.asList(mock(MetadataItem.class));
+    when(metadataService.getMetadataItemsByMetadataAndObject(any(MetadataKey.class),
+                                                             any(MetadataObject.class))).thenReturn(articleMetadataItems);
+
+    EntityManager entityManager = mock(EntityManager.class);
+    when(entityManagerService.getEntityManager()).thenReturn(entityManager);
+    Query query = mock(Query.class);
+    when(entityManager.createNativeQuery(anyString())).thenReturn(query);
+
+    Page articlePage = mock(Page.class);
+    when(noteService.getNoteById(nullable(String.class))).thenReturn(articlePage);
+
+    // Run the processUpgrade method
+    contentDraftArticlesUpgrade.processUpgrade("1.0", "2.0");
+
+    verify(newsService, times(2)).createNewsArticlePage(any(News.class), nullable(String.class));
+    verify(metadataService, times(4)).updateMetadataItem(any(), anyLong(), anyBoolean());
+    verify(activityManager, times(2)).updateActivity(any(ExoSocialActivity.class), eq(false));
+    verify(query, times(2)).executeUpdate();
+    verify(noteService, times(2)).updateNote(any(Page.class));
+  }
+
+  @Test
+  public void shouldProceedToUpgrade() {
+    SettingValue settingValue = mock(SettingValue.class);
+    UpgradePluginExecutionContext context = new UpgradePluginExecutionContext("0.9", 1);
+    when(settingService.get(any(), any(), anyString())).thenReturn(null);
+    contentDraftArticlesUpgrade.shouldProceedToUpgrade("0.9", "1.0", context);
+    verify(settingService, times(1)).set(any(), any(), anyString(), any());
+    reset(settingService);
+    when(settingService.get(any(), any(), anyString())).thenReturn(settingValue);
+    context.setVersion("1.2");
+    contentDraftArticlesUpgrade.shouldProceedToUpgrade("1.2", "1.0", context);
+    verify(settingService, times(0)).set(any(), any(), anyString(), any());
+  }
+}

--- a/data-upgrade-news/src/test/java/org/exoplatform/news/upgrade/jcr/NewsArticlesUpgradeTest.java
+++ b/data-upgrade-news/src/test/java/org/exoplatform/news/upgrade/jcr/NewsArticlesUpgradeTest.java
@@ -301,7 +301,7 @@ public class NewsArticlesUpgradeTest {
     when(startTimeProperty.getDate()).thenReturn(startTimePropertyCalendar);
     when(startTimePropertyCalendar.getTime()).thenReturn(mock(Date.class));
 
-    Method method = newsArticlesUpgrade.getClass().getDeclaredMethod("convertNewsNodeToNewEntity", Node.class, Node.class);
+    Method method = newsArticlesUpgrade.getClass().getDeclaredMethod("convertNewsNodeToNewsEntity", Node.class, Node.class);
     method.setAccessible(true);
     News news1 = (News) method.invoke(newsArticlesUpgrade, node1, null);
     News news2 = (News) method.invoke(newsArticlesUpgrade, node2, null);


### PR DESCRIPTION

When upgrading CERFRANCE from 6.5.5 to 7.0.0-M56, some articles are not well migrated.
In fact, it is a very specific case, these articles are posted with linked activities but their corresponding jcr nodes still have "draft" as current publication state instead of "published", so these articles are migrated as draft notes in the table "WIKI_DRAFT_PAGES" instead of the table "WIKI_PAGES". The migrated draft articles are well present in the "drafts" filter of news app.
We need an upgrade plugin to fix them following these steps:
- The UP will be launched only if a specific exo property exo.inconsistent.draftArticles="NOTE_DRAFT1_ID,ACTIVITY_ID1;NOTE_DRAFT2_ID,ACTIVITY_ID2...." is present.
- Create articles based on their data present on "WIKI_DRAFT_PAGES" table without generating activities.
- Update the value of "newsId" template param of each activity related to the created article by the article id.

Just for information, there's some information which can't be retrieved since it wasn't migrated via the inconsistent drafts, such as:
- Attachments
- Publication informations:
  - published in the stream or not (set as published by default)
  - published in NLV, audience (set as unpublished by default)
  - show author (set as no by default)
  - show reaction (set as no by default)