### PR TITLE
fix: Allow executing ContentDraftArticlesUpgrade UP for the same version - EXO-84269

### DIFF
--- a/data-upgrade-news/src/main/java/org/exoplatform/news/upgrade/ContentDraftArticlesUpgrade.java
+++ b/data-upgrade-news/src/main/java/org/exoplatform/news/upgrade/ContentDraftArticlesUpgrade.java
@@ -185,7 +185,8 @@ public class ContentDraftArticlesUpgrade extends UpgradeProductPlugin {
     SettingValue<?> settingValue = settingService.get(Context.GLOBAL.id(PLUGIN_NAME),
                                                       Scope.APPLICATION.id(PLUGIN_NAME),
                                                       PLUGIN_EXECUTED_KEY);
-    boolean shouldUpgrade = super.shouldProceedToUpgrade(newVersion, previousGroupVersion, upgradePluginExecutionContext);
+    int executionCount = upgradePluginExecutionContext == null ? 0 : upgradePluginExecutionContext.getExecutionCount();
+    boolean shouldUpgrade = !isExecuteOnlyOnce() || executionCount == 0;
     if (!shouldUpgrade && settingValue == null) {
       settingService.set(Context.GLOBAL.id(PLUGIN_NAME),
                          Scope.APPLICATION.id(PLUGIN_NAME),

--- a/data-upgrade-news/src/main/resources/conf/portal/configuration.xml
+++ b/data-upgrade-news/src/main/resources/conf/portal/configuration.xml
@@ -178,7 +178,7 @@
         <value-param>
           <name>plugin.upgrade.target.version</name>
           <description>Target version of the plugin</description>
-          <value>7.1.0</value>
+          <value>7.2.0</value>
         </value-param>
         <value-param>
           <name>content.inconsistent.draft.articles.upgrade</name>

--- a/data-upgrade-news/src/test/java/org/exoplatform/news/upgrade/ContentDraftArticlesUpgradeTest.java
+++ b/data-upgrade-news/src/test/java/org/exoplatform/news/upgrade/ContentDraftArticlesUpgradeTest.java
@@ -102,8 +102,12 @@ public class ContentDraftArticlesUpgradeTest {
     ValueParam valueParam2 = new ValueParam();
     valueParam2.setName("content.inconsistent.draft.articles.upgrade");
     valueParam2.setValue("1,1;2,2");
+    ValueParam valueParam3 = new ValueParam();
+    valueParam3.setName("plugin.upgrade.execute.once");
+    valueParam3.setValue("true");
     initParams.addParameter(valueParam1);
     initParams.addParameter(valueParam2);
+    initParams.addParameter(valueParam3);
     contentDraftArticlesUpgrade = new ContentDraftArticlesUpgrade(initParams,
                                                                   activityManager,
                                                                   identityManager,


### PR DESCRIPTION
Prior to this change, the ContentDraftArticlesUpgrade UP can not be executed for the same version which needs another additional upgrade to an upper version in order to fix the draft articles upgrade problem case. After this commit, in order to fix immediately the draft articles upgrade problem case, we will allow the execution of ContentDraftArticlesUpgrade UP for the same version to avoid an additional upgrade to an upper version. We will also ignore the target version restriction so that the UP can be executed for any version with always keeping the only once execution.