### PR TITLE
Fix: Implement an upgrade plugin to add publishers permissions for old spaces - EXO-85817

### DIFF
--- a/data-upgrade-documents-permissions/pom.xml
+++ b/data-upgrade-documents-permissions/pom.xml
@@ -1,0 +1,60 @@
+<!-- Copyright (C) 2026 eXo Platform SAS. This program is free software:
+  you can redistribute it and/or modify it under the terms of the GNU Affero
+  General Public License as published by the Free Software Foundation, either
+  version 3 of the License, or (at your option) any later version. This program
+  is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+  PURPOSE. See the GNU Affero General Public License for more details. You
+  should have received a copy of the GNU Affero General Public License along
+  with this program. If not, see <http://www.gnu.org/licenses/>. -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.exoplatform.addons.upgrade</groupId>
+    <artifactId>upgrade</artifactId>
+    <version>7.2.x-maintenance-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>data-upgrade-documents-permissions</artifactId>
+  <packaging>jar</packaging>
+  <name>eXo Add-on:: Data Upgrade Add-on - Documents Permissions</name>
+
+  <properties>
+    <exo.test.coverage.ratio>0.7</exo.test.coverage.ratio>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>io.meeds.social</groupId>
+      <artifactId>social-component-core</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.exoplatform.jcr</groupId>
+      <artifactId>exo.jcr.component.ext</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.exoplatform.ecms</groupId>
+      <artifactId>ecms-core-services</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.exoplatform.documents</groupId>
+      <artifactId>documents-api</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.exoplatform.documents</groupId>
+      <artifactId>documents-storage-jcr</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.exoplatform.documents</groupId>
+      <artifactId>documents-services</artifactId>
+      <scope>provided</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/data-upgrade-documents-permissions/src/main/java/org/exoplatform/migration/AddPublishersPermissionsUpgradePlugin.java
+++ b/data-upgrade-documents-permissions/src/main/java/org/exoplatform/migration/AddPublishersPermissionsUpgradePlugin.java
@@ -42,7 +42,6 @@ import org.exoplatform.services.jcr.core.ExtendedNode;
 import org.exoplatform.services.wcm.core.NodetypeConstant;
 import org.exoplatform.services.jcr.access.PermissionType;
 import io.meeds.common.ContainerTransactional;
-import org.exoplatform.documents.model.*;
 
 import jakarta.persistence.EntityManager;
 
@@ -133,6 +132,7 @@ public class AddPublishersPermissionsUpgradePlugin extends UpgradeProductPlugin 
       }
     } catch (Exception e) {
       LOG.error("An error occurred when upgrading redactional spaces documents:", e);
+      this.upgradeFailed = true;
     } finally {
       if (sessionProvider != null) {
         sessionProvider.close();

--- a/data-upgrade-documents-permissions/src/main/java/org/exoplatform/migration/AddPublishersPermissionsUpgradePlugin.java
+++ b/data-upgrade-documents-permissions/src/main/java/org/exoplatform/migration/AddPublishersPermissionsUpgradePlugin.java
@@ -70,6 +70,8 @@ public class AddPublishersPermissionsUpgradePlugin extends UpgradeProductPlugin 
 
   private static final String    PLUGIN_EXECUTED_KEY            = "permissionsUpgradeExecuted";
 
+  private static final String    COMPLETED_SPACES_KEY           = "completedSpaceIds";
+
   private boolean                upgradeFailed                  = false;
 
   private SpaceService           spaceService;
@@ -107,6 +109,8 @@ public class AddPublishersPermissionsUpgradePlugin extends UpgradeProductPlugin 
     int notMigratedRedactionalSpacesCount = 0;
     int processedRedactionalSpacesCount = 0;
     int totalRedactionalSpacesCount = 0;
+    int alreadyCompletedCount = 0;
+    Set<String> completedSpaceIds = getCompletedSpaceIds();
     try {
       ManageableRepository repository = repositoryService.getCurrentRepository();
       sessionProvider = sessionProviderService.getSystemSessionProvider(null);
@@ -116,17 +120,37 @@ public class AddPublishersPermissionsUpgradePlugin extends UpgradeProductPlugin 
       if (spaceIds.isEmpty()) {
         return;
       }
+
+      List<Long> remainingSpaces = new ArrayList<>();
+      for (Long id : spaceIds) {
+        if (!completedSpaceIds.contains(id.toString())) {
+          remainingSpaces.add(id);
+        } else {
+          alreadyCompletedCount++;
+        }
+      }
+
+      if (remainingSpaces.isEmpty()) {
+        LOG.info("All redactional spaces were already migrated");
+        processedRedactionalSpacesCount = spaceIds.size();
+        migratedRedactionalSpacesCount = alreadyCompletedCount;
+        totalRedactionalSpacesCount = spaceIds.size();
+        return;
+      }
+
       totalRedactionalSpacesCount = spaceIds.size();
-      LOG.info("Total number of redactional spaces to be migrated: {}", totalRedactionalSpacesCount);
-      for (List<Long> spaceIdsChunk : ListUtils.partition(spaceIds, 10)) {
-        int notMigratedRedactionalSpacesCountByTransaction = manageDocumentsPermissions(spaceIdsChunk, session);
+      LOG.info("Total redactional spaces: {}, remaining to migrate: {}",
+               totalRedactionalSpacesCount, remainingSpaces.size());
+      for (List<Long> spaceIdsChunk : ListUtils.partition(remainingSpaces, 10)) {
+        int notMigratedRedactionalSpacesCountByTransaction = manageDocumentsPermissions(spaceIdsChunk, session, completedSpaceIds);
         int processedRedactionalSpacesCountByTransaction = spaceIdsChunk.size();
         processedRedactionalSpacesCount += processedRedactionalSpacesCountByTransaction;
         migratedRedactionalSpacesCount += processedRedactionalSpacesCountByTransaction - notMigratedRedactionalSpacesCountByTransaction;
         notMigratedRedactionalSpacesCount += notMigratedRedactionalSpacesCountByTransaction;
+        saveCompletedSpaceIds(completedSpaceIds);
         LOG.info("Redactional spaces documents migration progress: processed={}/{} succeeded={} error={}",
                 processedRedactionalSpacesCount,
-                totalRedactionalSpacesCount,
+                remainingSpaces.size(),
                 migratedRedactionalSpacesCount,
                 notMigratedRedactionalSpacesCount);
       }
@@ -138,7 +162,7 @@ public class AddPublishersPermissionsUpgradePlugin extends UpgradeProductPlugin 
         sessionProvider.close();
       }
     }
-    if (totalRedactionalSpacesCount == migratedRedactionalSpacesCount) {
+    if (alreadyCompletedCount + migratedRedactionalSpacesCount == totalRedactionalSpacesCount) {
       LOG.info("End redactional spaces documents migration successful migration: total={} succeeded={} error={}. It tooks {} ms.",
               totalRedactionalSpacesCount,
               migratedRedactionalSpacesCount,
@@ -159,6 +183,9 @@ public class AddPublishersPermissionsUpgradePlugin extends UpgradeProductPlugin 
   @Override
   public void afterUpgrade() {
     if (!upgradeFailed) {
+      settingService.remove(Context.GLOBAL.id(PLUGIN_NAME),
+                            Scope.APPLICATION.id(PLUGIN_NAME),
+                            COMPLETED_SPACES_KEY);
       settingService.set(Context.GLOBAL.id(PLUGIN_NAME),
               Scope.APPLICATION.id(PLUGIN_NAME),
               PLUGIN_EXECUTED_KEY,
@@ -193,9 +220,34 @@ public class AddPublishersPermissionsUpgradePlugin extends UpgradeProductPlugin 
     return query.getResultList();
   }
 
-  private int manageDocumentsPermissions(List<Long> spaceIds, Session session) {
+  private Set<String> getCompletedSpaceIds() {
+    SettingValue<?> value = settingService.get(Context.GLOBAL.id(PLUGIN_NAME),
+                                               Scope.APPLICATION.id(PLUGIN_NAME),
+                                               COMPLETED_SPACES_KEY);
+    if (value == null || value.getValue() == null) {
+      return new HashSet<>();
+    }
+    String csv = (String) value.getValue();
+    if (StringUtils.isBlank(csv)) {
+      return new HashSet<>();
+    }
+    return new HashSet<>(Arrays.asList(csv.split(",")));
+  }
+
+  private void saveCompletedSpaceIds(Set<String> completedIds) {
+    String csv = String.join(",", completedIds);
+    settingService.set(Context.GLOBAL.id(PLUGIN_NAME),
+                       Scope.APPLICATION.id(PLUGIN_NAME),
+                       COMPLETED_SPACES_KEY,
+                       SettingValue.create(csv));
+  }
+
+  private int manageDocumentsPermissions(List<Long> spaceIds, Session session, Set<String> completedSpaceIds) {
     int notMigratedRedactionalSpacesCountByTransaction = 0;
     for (Long spaceId : spaceIds) {
+      if (completedSpaceIds.contains(spaceId.toString())) {
+        continue;
+      }
       try {
         Space space = spaceService.getSpaceById(spaceId.toString());
         LOG.info("Migrating redactional space documents with id '{}' and name '{}'", spaceId, space.getPrettyName());
@@ -204,6 +256,7 @@ public class AddPublishersPermissionsUpgradePlugin extends UpgradeProductPlugin 
           applyPublisherPermissions(spaceRootNode, space);
           session.save();
         }
+        completedSpaceIds.add(spaceId.toString());
         LOG.info("Success migrating redactional space documents with id '{}' and name '{}'", spaceId, space.getPrettyName());
       } catch (Exception e) {
         notMigratedRedactionalSpacesCountByTransaction++;

--- a/data-upgrade-documents-permissions/src/main/java/org/exoplatform/migration/AddPublishersPermissionsUpgradePlugin.java
+++ b/data-upgrade-documents-permissions/src/main/java/org/exoplatform/migration/AddPublishersPermissionsUpgradePlugin.java
@@ -1,0 +1,261 @@
+/*
+ * Copyright (C) 2026 eXo Platform SAS.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.exoplatform.migration;
+
+import io.meeds.social.space.constant.SpaceMembershipStatus;
+import jakarta.persistence.TypedQuery;
+import org.apache.commons.collections4.ListUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.exoplatform.commons.api.settings.SettingService;
+import org.exoplatform.commons.api.settings.SettingValue;
+import org.exoplatform.commons.api.settings.data.Context;
+import org.exoplatform.commons.api.settings.data.Scope;
+import org.exoplatform.commons.upgrade.UpgradePluginExecutionContext;
+import org.exoplatform.commons.upgrade.UpgradeProductPlugin;
+import org.exoplatform.container.xml.InitParams;
+import org.exoplatform.services.jcr.access.AccessControlEntry;
+import org.exoplatform.services.log.ExoLogger;
+import org.exoplatform.services.log.Log;
+import org.exoplatform.social.core.space.spi.SpaceService;
+import org.exoplatform.social.core.space.model.Space;
+import org.exoplatform.services.jcr.ext.common.SessionProvider;
+import org.exoplatform.services.jcr.ext.app.SessionProviderService;
+import org.exoplatform.services.jcr.RepositoryService;
+import org.exoplatform.commons.persistence.impl.EntityManagerService;
+import org.exoplatform.services.jcr.core.ManageableRepository;
+import org.exoplatform.services.jcr.ext.hierarchy.NodeHierarchyCreator;
+import org.exoplatform.services.jcr.core.ExtendedNode;
+import org.exoplatform.services.wcm.core.NodetypeConstant;
+import org.exoplatform.services.jcr.access.PermissionType;
+import io.meeds.common.ContainerTransactional;
+import org.exoplatform.documents.model.*;
+
+import jakarta.persistence.EntityManager;
+
+import javax.jcr.Node;
+import javax.jcr.NodeIterator;
+import javax.jcr.RepositoryException;
+import javax.jcr.Session;
+
+import java.util.*;
+
+public class AddPublishersPermissionsUpgradePlugin extends UpgradeProductPlugin {
+
+  private static final Log       LOG                            = ExoLogger.getExoLogger(AddPublishersPermissionsUpgradePlugin.class);
+
+  private static final String    DEFAULT_GROUPS_HOME_PATH       = "/Groups";
+
+  public static final String     GROUPS_PATH_ALIAS              = "groupsPath";
+
+  public static final String     DOCUMENTS_NODE                 = "Documents";
+
+  private static String          groupsPath                     = null;
+
+  private int                    migratedRedactionalSpacesCount = 0;
+
+  private static final String    PLUGIN_NAME                    = "PublishersPermissionsUpgradePlugin";
+
+  private static final String    PLUGIN_EXECUTED_KEY            = "permissionsUpgradeExecuted";
+
+  private boolean                upgradeFailed                  = false;
+
+  private SpaceService           spaceService;
+
+  private SessionProviderService sessionProviderService;
+
+  private RepositoryService      repositoryService;
+
+  private EntityManagerService   entityManagerService;
+
+  private NodeHierarchyCreator   nodeHierarchyCreator;
+
+  private SettingService         settingService;
+
+  public AddPublishersPermissionsUpgradePlugin(InitParams initParams,
+                                               SpaceService spaceService,
+                                               SessionProviderService sessionProviderService,
+                                               RepositoryService repositoryService,
+                                               EntityManagerService entityManagerService,
+                                               NodeHierarchyCreator nodeHierarchyCreator,
+                                               SettingService settingService) {
+    super(initParams);
+    this.spaceService = spaceService;
+    this.sessionProviderService = sessionProviderService;
+    this.repositoryService = repositoryService;
+    this.entityManagerService = entityManagerService;
+    this.nodeHierarchyCreator = nodeHierarchyCreator;
+    this.settingService = settingService;
+  }
+  @Override
+  public void processUpgrade(String oldVersion, String newVersion) {
+    long startupTime = System.currentTimeMillis();
+    LOG.info("Start Upgrade of redactional spaces documents");
+    SessionProvider sessionProvider = null;
+    int notMigratedRedactionalSpacesCount = 0;
+    int processedRedactionalSpacesCount = 0;
+    int totalRedactionalSpacesCount = 0;
+    try {
+      ManageableRepository repository = repositoryService.getCurrentRepository();
+      sessionProvider = sessionProviderService.getSystemSessionProvider(null);
+      Session session = sessionProvider.getSession("collaboration", repository);
+
+      List<Long> spaceIds = getRedactionalSpaces();
+      if (spaceIds.isEmpty()) {
+        return;
+      }
+      totalRedactionalSpacesCount = spaceIds.size();
+      LOG.info("Total number of redactional spaces to be migrated: {}", totalRedactionalSpacesCount);
+      for (List<Long> spaceIdsChunk : ListUtils.partition(spaceIds, 10)) {
+        int notMigratedRedactionalSpacesCountByTransaction = manageDocumentsPermissions(spaceIdsChunk, session);
+        int processedRedactionalSpacesCountByTransaction = spaceIdsChunk.size();
+        processedRedactionalSpacesCount += processedRedactionalSpacesCountByTransaction;
+        migratedRedactionalSpacesCount += processedRedactionalSpacesCountByTransaction - notMigratedRedactionalSpacesCountByTransaction;
+        notMigratedRedactionalSpacesCount += notMigratedRedactionalSpacesCountByTransaction;
+        LOG.info("Redactional spaces documents migration progress: processed={}/{} succeeded={} error={}",
+                processedRedactionalSpacesCount,
+                totalRedactionalSpacesCount,
+                migratedRedactionalSpacesCount,
+                notMigratedRedactionalSpacesCount);
+      }
+    } catch (Exception e) {
+      LOG.error("An error occurred when upgrading redactional spaces documents:", e);
+    } finally {
+      if (sessionProvider != null) {
+        sessionProvider.close();
+      }
+    }
+    if (totalRedactionalSpacesCount == migratedRedactionalSpacesCount) {
+      LOG.info("End redactional spaces documents migration successful migration: total={} succeeded={} error={}. It tooks {} ms.",
+              totalRedactionalSpacesCount,
+              migratedRedactionalSpacesCount,
+              notMigratedRedactionalSpacesCount,
+              (System.currentTimeMillis() - startupTime));
+    } else {
+      LOG.warn("End redactional spaces documents migration with some errors: total={} succeeded={} error={}. It tooks {} ms."
+              + " The not migrated redactional spaces documents will be processed again next startup.",
+              totalRedactionalSpacesCount,
+              migratedRedactionalSpacesCount,
+              notMigratedRedactionalSpacesCount,
+              (System.currentTimeMillis() - startupTime));
+      this.upgradeFailed = true;
+      throw new IllegalStateException("Some redactional spaces documents wasn't executed successfully. It will be re-attempted next startup");
+    }
+  }
+
+  @Override
+  public void afterUpgrade() {
+    if (!upgradeFailed) {
+      settingService.set(Context.GLOBAL.id(PLUGIN_NAME),
+              Scope.APPLICATION.id(PLUGIN_NAME),
+              PLUGIN_EXECUTED_KEY,
+              SettingValue.create(true));
+    }
+  }
+
+  @Override
+  public boolean shouldProceedToUpgrade(String newVersion,
+                                        String previousGroupVersion,
+                                        UpgradePluginExecutionContext upgradePluginExecutionContext) {
+    SettingValue<?> settingValue = settingService.get(Context.GLOBAL.id(PLUGIN_NAME),
+            Scope.APPLICATION.id(PLUGIN_NAME),
+            PLUGIN_EXECUTED_KEY);
+    boolean shouldUpgrade = super.shouldProceedToUpgrade(newVersion, previousGroupVersion, upgradePluginExecutionContext);
+    if (!shouldUpgrade && settingValue == null) {
+      settingService.set(Context.GLOBAL.id(PLUGIN_NAME),
+              Scope.APPLICATION.id(PLUGIN_NAME),
+              PLUGIN_EXECUTED_KEY,
+              SettingValue.create(true));
+    }
+    return shouldUpgrade;
+  }
+
+  @ContainerTransactional
+  public List<Long> getRedactionalSpaces() {
+    EntityManager entityManager = entityManagerService.getEntityManager();
+    String selectQuery = "SELECT DISTINCT sm.space.id FROM SocSpaceMember sm "
+                         + "WHERE sm.status = :status";
+    TypedQuery<Long> query = entityManager.createQuery(selectQuery, Long.class);
+    query.setParameter("status", SpaceMembershipStatus.REDACTOR);
+    return query.getResultList();
+  }
+
+  private int manageDocumentsPermissions(List<Long> spaceIds, Session session) {
+    int notMigratedRedactionalSpacesCountByTransaction = 0;
+    for (Long spaceId : spaceIds) {
+      try {
+        Space space = spaceService.getSpaceById(spaceId.toString());
+        LOG.info("Migrating redactional space documents with id '{}' and name '{}'", spaceId, space.getPrettyName());
+        Node spaceRootNode = getGroupNode(nodeHierarchyCreator, session, space.getGroupId());
+        if (spaceRootNode != null) {
+          applyPublisherPermissions(spaceRootNode, space);
+          session.save();
+        }
+        LOG.info("Success migrating redactional space documents with id '{}' and name '{}'", spaceId, space.getPrettyName());
+      } catch (Exception e) {
+        notMigratedRedactionalSpacesCountByTransaction++;
+        LOG.warn("Error migrating redactional space documents with id '{}'. Continue to migrate other items", spaceId, e);
+      }
+    }
+    return notMigratedRedactionalSpacesCountByTransaction;
+  }
+
+  private void applyPublisherPermissions(Node parentNode, Space space) throws RepositoryException {
+    NodeIterator children = parentNode.getNodes();
+    while (children.hasNext()) {
+      Node child = children.nextNode();
+      LOG.info("Updating publisher permissions for node '{}'", child.getPath());
+      ExtendedNode extNode = (ExtendedNode) child;
+      if (extNode.isNodeType(NodetypeConstant.EXO_PRIVILEGEABLE)) {
+        List<AccessControlEntry> permissions = extNode.getACL().getPermissionEntries();
+        boolean hasManager = permissions.stream()
+                .anyMatch(p -> p.getIdentity().equals("manager:" + space.getGroupId()));
+        boolean hasRedactor = permissions.stream()
+                .anyMatch(p -> p.getIdentity().equals("redactor:" + space.getGroupId()));
+        boolean hasPublisher = permissions.stream()
+                .anyMatch(p -> p.getIdentity().equals("publisher:" + space.getGroupId()));
+        if (hasManager && hasRedactor && !hasPublisher) {
+          extNode.setPermission("publisher:" + space.getGroupId(), PermissionType.ALL);
+        }
+      }
+      child.save();
+      applyPublisherPermissions(child, space);
+    }
+  }
+
+  private static Node getGroupNode(NodeHierarchyCreator nodeHierarchyCreator,
+                                  Session session,
+                                  String groupId) throws RepositoryException {
+    String groupsHomePath = getGroupsPath(nodeHierarchyCreator);
+    String groupPath = groupsHomePath + groupId + "/" + DOCUMENTS_NODE; // NOSONAR
+    if (session.itemExists(groupPath)) {
+      return (Node) session.getItem(groupPath);
+    }
+    return null;
+  }
+
+  private static String getGroupsPath(NodeHierarchyCreator nodeHierarchyCreator) {
+    if (groupsPath != null) {
+      return groupsPath;
+    }
+    groupsPath = nodeHierarchyCreator.getJcrPath(GROUPS_PATH_ALIAS);
+    if (StringUtils.isBlank(groupsPath)) {
+      groupsPath = DEFAULT_GROUPS_HOME_PATH;
+    }
+    return groupsPath;
+  }
+}
+

--- a/data-upgrade-documents-permissions/src/main/resources/conf/portal/configuration.xml
+++ b/data-upgrade-documents-permissions/src/main/resources/conf/portal/configuration.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Copyright (C) 2026 eXo Platform SAS. This program is free software:
+  you can redistribute it and/or modify it under the terms of the GNU Affero 
+  General Public License as published by the Free Software Foundation, either 
+  version 3 of the License, or (at your option) any later version. This program 
+  is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; 
+  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR 
+  PURPOSE. See the GNU Affero General Public License for more details. You 
+  should have received a copy of the GNU Affero General Public License along 
+  with this program. If not, see <http://www.gnu.org/licenses/>. -->
+
+<configuration xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.exoplatform.org/xml/ns/kernel_1_3.xsd http://www.exoplatform.org/xml/ns/kernel_1_3.xsd" xmlns="http://www.exoplatform.org/xml/ns/kernel_1_3.xsd">
+
+  <external-component-plugins>
+    <target-component>org.exoplatform.commons.upgrade.UpgradeProductService</target-component>
+    <component-plugin>
+      <name>AddPublishersPermissionsUpgradePlugin</name>
+      <set-method>addUpgradePlugin</set-method>
+      <type>org.exoplatform.migration.AddPublishersPermissionsUpgradePlugin</type>
+      <description>Adds permissions to existing publisher spaces</description>
+      <init-params>
+        <value-param>
+          <name>product.group.id</name>
+          <description>The groupId of the product</description>
+          <value>org.exoplatform.platform</value>
+        </value-param>
+        <value-param>
+          <name>plugin.execution.order</name>
+          <description>The plugin execution order</description>
+          <value>10</value>
+        </value-param>
+        <value-param>
+          <name>plugin.upgrade.execute.once</name>
+          <description>The plugin must be executed only once</description>
+          <value>true</value>
+        </value-param>
+        <value-param>
+          <name>plugin.upgrade.async.execution</name>
+          <description>The plugin will be executed in an asynchronous mode</description>
+          <value>true</value>
+        </value-param>
+      </init-params>
+    </component-plugin>
+  </external-component-plugins>
+</configuration>
+

--- a/data-upgrade-documents-permissions/src/test/java/org/exoplatform/migration/AddPublishersPermissionsUpgradePluginTest.java
+++ b/data-upgrade-documents-permissions/src/test/java/org/exoplatform/migration/AddPublishersPermissionsUpgradePluginTest.java
@@ -16,22 +16,14 @@
  */
 package org.exoplatform.migration;
 
-import org.exoplatform.commons.api.settings.SettingValue;
-import org.exoplatform.commons.upgrade.UpgradePluginExecutionContext;
-import org.exoplatform.container.xml.InitParams;
-import org.exoplatform.commons.persistence.impl.EntityManagerService;
-import org.exoplatform.commons.api.settings.SettingService;
-import org.exoplatform.container.xml.ValueParam;
-import org.exoplatform.services.jcr.RepositoryService;
-import org.exoplatform.services.jcr.access.PermissionType;
-import org.exoplatform.services.jcr.config.RepositoryEntry;
-import org.exoplatform.services.jcr.core.ExtendedNode;
-import org.exoplatform.services.jcr.core.ManageableRepository;
-import org.exoplatform.services.jcr.ext.app.SessionProviderService;
-import org.exoplatform.services.jcr.ext.common.SessionProvider;
-import org.exoplatform.services.jcr.ext.hierarchy.NodeHierarchyCreator;
-import org.exoplatform.social.core.space.spi.SpaceService;
-import org.exoplatform.social.core.space.model.Space;
+import static org.junit.Assert.assertThrows;
+import static org.mockito.Mockito.*;
+
+import java.util.Collections;
+import java.util.List;
+
+import javax.jcr.NodeIterator;
+import javax.jcr.Session;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -39,14 +31,22 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
-import javax.jcr.NodeIterator;
-import javax.jcr.Session;
-import javax.jcr.Workspace;
-import javax.jcr.nodetype.NodeType;
-
-import java.util.Collections;
-
-import static org.mockito.Mockito.*;
+import org.exoplatform.commons.api.settings.SettingService;
+import org.exoplatform.commons.api.settings.SettingValue;
+import org.exoplatform.commons.upgrade.UpgradePluginExecutionContext;
+import org.exoplatform.container.xml.InitParams;
+import org.exoplatform.container.xml.ValueParam;
+import org.exoplatform.services.jcr.RepositoryService;
+import org.exoplatform.services.jcr.access.AccessControlEntry;
+import org.exoplatform.services.jcr.access.AccessControlList;
+import org.exoplatform.services.jcr.access.PermissionType;
+import org.exoplatform.services.jcr.core.ExtendedNode;
+import org.exoplatform.services.jcr.core.ManageableRepository;
+import org.exoplatform.services.jcr.ext.app.SessionProviderService;
+import org.exoplatform.services.jcr.ext.common.SessionProvider;
+import org.exoplatform.services.jcr.ext.hierarchy.NodeHierarchyCreator;
+import org.exoplatform.social.core.space.model.Space;
+import org.exoplatform.social.core.space.spi.SpaceService;
 
 @RunWith(MockitoJUnitRunner.class)
 public class AddPublishersPermissionsUpgradePluginTest {
@@ -61,9 +61,6 @@ public class AddPublishersPermissionsUpgradePluginTest {
   private RepositoryService                     repositoryService;
 
   @Mock
-  private EntityManagerService                  entityManagerService;
-
-  @Mock
   private SettingService                        settingService;
 
   @Mock
@@ -73,9 +70,6 @@ public class AddPublishersPermissionsUpgradePluginTest {
   private ManageableRepository                  repository;
 
   @Mock
-  private RepositoryEntry                       repositoryEntry;
-
-  @Mock
   private ExtendedNode                          extendedNode;
 
   private AddPublishersPermissionsUpgradePlugin addPublishersPermissionsUpgradePlugin;
@@ -83,52 +77,65 @@ public class AddPublishersPermissionsUpgradePluginTest {
   @Before
   public void setUp() {
     InitParams initParams = new InitParams();
-
     ValueParam valueParam = new ValueParam();
     valueParam.setName("product.group.id");
     valueParam.setValue("org.exoplatform.platform");
     initParams.addParameter(valueParam);
     addPublishersPermissionsUpgradePlugin = spy(new AddPublishersPermissionsUpgradePlugin(initParams,
-                                                                                      spaceService,
-                                                                                      sessionProviderService,
-                                                                                      repositoryService,
-                                                                                      entityManagerService,
-                                                                                      nodeHierarchyCreator,
-                                                                                      settingService));
+                                                                                       spaceService,
+                                                                                       sessionProviderService,
+                                                                                       repositoryService,
+                                                                                       null,
+                                                                                       nodeHierarchyCreator,
+                                                                                       settingService));
+  }
+
+  private Session mockSession() throws Exception {
+    lenient().when(repositoryService.getCurrentRepository()).thenReturn(repository);
+    SessionProvider sessionProvider = mock(SessionProvider.class);
+    when(sessionProviderService.getSystemSessionProvider(any())).thenReturn(sessionProvider);
+    Session session = mock(Session.class);
+    when(sessionProvider.getSession(anyString(), any(ManageableRepository.class))).thenReturn(session);
+    return session;
+  }
+
+  private void mockRootNodeWithChildren(Session session, boolean privilegeable, boolean hasPublisher) throws Exception {
+    lenient().when(nodeHierarchyCreator.getJcrPath(AddPublishersPermissionsUpgradePlugin.GROUPS_PATH_ALIAS)).thenReturn("/Groups/");
+    when(session.itemExists(anyString())).thenReturn(true);
+    when(session.getItem(anyString())).thenReturn(extendedNode);
+
+    NodeIterator nodeIterator = mock(NodeIterator.class);
+    when(nodeIterator.hasNext()).thenReturn(true, false);
+    when(nodeIterator.nextNode()).thenReturn(extendedNode);
+    when(extendedNode.getNodes()).thenReturn(nodeIterator);
+
+    when(extendedNode.isNodeType("exo:privilegeable")).thenReturn(privilegeable);
+    if (privilegeable) {
+      AccessControlEntry managerEntry = new AccessControlEntry("manager:/platform/users", "read");
+      AccessControlEntry redactorEntry = new AccessControlEntry("redactor:/platform/users", "read");
+      List<AccessControlEntry> aclEntries;
+      if (hasPublisher) {
+        aclEntries = List.of(managerEntry, redactorEntry,
+                             new AccessControlEntry("publisher:/platform/users", "read"));
+      } else {
+        aclEntries = List.of(managerEntry, redactorEntry);
+      }
+      when(extendedNode.getACL()).thenReturn(new AccessControlList("root", aclEntries));
+    }
   }
 
   @Test
   public void testProcessUpgrade_successfulMigration() throws Exception {
-    // Mock space
     Space space = new Space();
     space.setId("1");
     space.setGroupId("/platform/users");
     space.setPrettyName("TestSpace");
     when(spaceService.getSpaceById("1")).thenReturn(space);
 
-    lenient().when(repositoryService.getCurrentRepository()).thenReturn(repository);
-    SessionProvider sessionProvider = mock(SessionProvider.class);
-    when(sessionProviderService.getSystemSessionProvider(any())).thenReturn(sessionProvider);
-    Session session = mock(Session.class);
-    when(sessionProvider.getSession(anyString(), any(ManageableRepository.class))).thenReturn(session);
-    Workspace workspace = mock(Workspace.class);
-    lenient().when(session.getWorkspace()).thenReturn(workspace);
-
-    when(nodeHierarchyCreator.getJcrPath(AddPublishersPermissionsUpgradePlugin.GROUPS_PATH_ALIAS))
-            .thenReturn("/Groups/");
-    when(session.itemExists(anyString())).thenReturn(true);
-    when(session.getItem(anyString())).thenReturn(extendedNode);
-
-    NodeType nodeType = mock(NodeType.class);
-    when(nodeType.getName()).thenReturn("nt:file");
-    when(extendedNode.getPrimaryNodeType()).thenReturn(nodeType);
-    NodeIterator nodeIterator = mock(NodeIterator.class);
-    when(nodeIterator.hasNext()).thenReturn(true, false);
-    when(nodeIterator.nextNode()).thenReturn(extendedNode);
-    when(extendedNode.getNodes()).thenReturn(nodeIterator);
+    Session session = mockSession();
+    mockRootNodeWithChildren(session, true, false);
 
     doReturn(Collections.singletonList(1L)).when(addPublishersPermissionsUpgradePlugin).getRedactionalSpaces();
-    // Run the processUpgrade method
     addPublishersPermissionsUpgradePlugin.processUpgrade("1.0", "2.0");
 
     verify(extendedNode).setPermission("publisher:/platform/users", PermissionType.ALL);
@@ -137,26 +144,113 @@ public class AddPublishersPermissionsUpgradePluginTest {
   }
 
   @Test
-  public void testProcessUpgrade_noSpaces() {
-    // No spaces to migrate
-    lenient().doReturn(Collections.emptyList()).when(addPublishersPermissionsUpgradePlugin).getRedactionalSpaces();
-    // Run the processUpgrade method
+  public void testProcessUpgrade_noSpaces() throws Exception {
+    mockSession();
+    doReturn(Collections.emptyList()).when(addPublishersPermissionsUpgradePlugin).getRedactionalSpaces();
     addPublishersPermissionsUpgradePlugin.processUpgrade("1.0", "2.0");
-
     verify(spaceService, never()).getSpaceById(anyString());
   }
 
   @Test
-  public void shouldProceedToUpgrade() {
-    SettingValue settingValue = mock(SettingValue.class);
-    UpgradePluginExecutionContext context = new UpgradePluginExecutionContext("0.9", 1);
+  public void testProcessUpgrade_spaceRootNodeIsNull() throws Exception {
+    Space space = new Space();
+    space.setId("1");
+    space.setGroupId("/platform/users");
+    space.setPrettyName("TestSpace");
+    when(spaceService.getSpaceById("1")).thenReturn(space);
+
+    Session session = mockSession();
+    lenient().when(nodeHierarchyCreator.getJcrPath(AddPublishersPermissionsUpgradePlugin.GROUPS_PATH_ALIAS)).thenReturn("/Groups/");
+    when(session.itemExists(anyString())).thenReturn(false);
+
+    doReturn(Collections.singletonList(1L)).when(addPublishersPermissionsUpgradePlugin).getRedactionalSpaces();
+    addPublishersPermissionsUpgradePlugin.processUpgrade("1.0", "2.0");
+    verify(session, never()).save();
+  }
+
+  @Test
+  public void testProcessUpgrade_nodeAlreadyHasPublisher() throws Exception {
+    Space space = new Space();
+    space.setId("1");
+    space.setGroupId("/platform/users");
+    space.setPrettyName("TestSpace");
+    when(spaceService.getSpaceById("1")).thenReturn(space);
+
+    Session session = mockSession();
+    mockRootNodeWithChildren(session, true, true);
+
+    doReturn(Collections.singletonList(1L)).when(addPublishersPermissionsUpgradePlugin).getRedactionalSpaces();
+    addPublishersPermissionsUpgradePlugin.processUpgrade("1.0", "2.0");
+
+    verify(extendedNode, never()).setPermission(anyString(), any(String[].class));
+    verify(session).save();
+  }
+
+  @Test
+  public void testProcessUpgrade_nonPrivilegeableNode() throws Exception {
+    Space space = new Space();
+    space.setId("1");
+    space.setGroupId("/platform/users");
+    space.setPrettyName("TestSpace");
+    when(spaceService.getSpaceById("1")).thenReturn(space);
+
+    Session session = mockSession();
+    mockRootNodeWithChildren(session, false, false);
+
+    doReturn(Collections.singletonList(1L)).when(addPublishersPermissionsUpgradePlugin).getRedactionalSpaces();
+    addPublishersPermissionsUpgradePlugin.processUpgrade("1.0", "2.0");
+
+    verify(extendedNode, never()).setPermission(anyString(), any(String[].class));
+    verify(session).save();
+  }
+
+  @Test
+  public void testProcessUpgrade_someSpacesFail() throws Exception {
+    mockSession();
+    when(spaceService.getSpaceById("1")).thenThrow(new RuntimeException("space error"));
+
+    doReturn(Collections.singletonList(1L)).when(addPublishersPermissionsUpgradePlugin).getRedactionalSpaces();
+    assertThrows(IllegalStateException.class,
+                 () -> addPublishersPermissionsUpgradePlugin.processUpgrade("1.0", "2.0"));
+  }
+
+  @Test
+  public void testProcessUpgrade_errorGettingRepository() throws Exception {
+    lenient().when(repositoryService.getCurrentRepository()).thenThrow(new RuntimeException("DB error"));
+    addPublishersPermissionsUpgradePlugin.processUpgrade("1.0", "2.0");
+    verify(settingService, never()).set(any(), any(), any(), any());
+  }
+
+  @Test
+  public void testAfterUpgrade_whenUpgradeFailed() throws Exception {
+    lenient().when(repositoryService.getCurrentRepository()).thenThrow(new RuntimeException("error"));
+    addPublishersPermissionsUpgradePlugin.processUpgrade("1.0", "2.0");
+    addPublishersPermissionsUpgradePlugin.afterUpgrade();
+    verify(settingService, never()).set(any(), any(), any(), any());
+  }
+
+  @Test
+  public void testAfterUpgrade_whenUpgradeSucceeded() throws Exception {
+    mockSession();
+    doReturn(Collections.emptyList()).when(addPublishersPermissionsUpgradePlugin).getRedactionalSpaces();
+    addPublishersPermissionsUpgradePlugin.processUpgrade("1.0", "2.0");
+    addPublishersPermissionsUpgradePlugin.afterUpgrade();
+    verify(settingService, times(1)).set(any(), any(), anyString(), any());
+  }
+
+  @Test
+  public void shouldProceedToUpgrade_settingNotSet() {
     when(settingService.get(any(), any(), anyString())).thenReturn(null);
+    UpgradePluginExecutionContext context = new UpgradePluginExecutionContext("0.9", 1);
     addPublishersPermissionsUpgradePlugin.shouldProceedToUpgrade("0.9", "1.0", context);
     verify(settingService, times(1)).set(any(), any(), anyString(), any());
-    reset(settingService);
-    when(settingService.get(any(), any(), anyString())).thenReturn(settingValue);
-    context.setVersion("1.2");
+  }
+
+  @Test
+  public void shouldProceedToUpgrade_settingAlreadySet() {
+    when(settingService.get(any(), any(), anyString())).thenReturn(mock(SettingValue.class));
+    UpgradePluginExecutionContext context = new UpgradePluginExecutionContext("1.2", 1);
     addPublishersPermissionsUpgradePlugin.shouldProceedToUpgrade("1.2", "1.0", context);
-    verify(settingService, times(0)).set(any(), any(), anyString(), any());
+    verify(settingService, never()).set(any(), any(), anyString(), any());
   }
 }

--- a/data-upgrade-documents-permissions/src/test/java/org/exoplatform/migration/AddPublishersPermissionsUpgradePluginTest.java
+++ b/data-upgrade-documents-permissions/src/test/java/org/exoplatform/migration/AddPublishersPermissionsUpgradePluginTest.java
@@ -205,6 +205,24 @@ public class AddPublishersPermissionsUpgradePluginTest {
   }
 
   @Test
+  public void testProcessUpgrade_resumeFromCheckpoint() throws Exception {
+    when(settingService.get(any(), any(), anyString())).thenAnswer(invocation -> SettingValue.create("2"));
+
+    Space space1 = new Space();
+    space1.setId("1");
+    space1.setGroupId("/platform/users");
+    space1.setPrettyName("Space1");
+    when(spaceService.getSpaceById("1")).thenReturn(space1);
+
+    mockSession();
+    doReturn(List.of(1L, 2L)).when(addPublishersPermissionsUpgradePlugin).getRedactionalSpaces();
+    addPublishersPermissionsUpgradePlugin.processUpgrade("1.0", "2.0");
+
+    verify(spaceService, never()).getSpaceById("2");
+    verify(spaceService, times(1)).getSpaceById("1");
+  }
+
+  @Test
   public void testProcessUpgrade_someSpacesFail() throws Exception {
     mockSession();
     when(spaceService.getSpaceById("1")).thenThrow(new RuntimeException("space error"));

--- a/data-upgrade-documents-permissions/src/test/java/org/exoplatform/migration/AddPublishersPermissionsUpgradePluginTest.java
+++ b/data-upgrade-documents-permissions/src/test/java/org/exoplatform/migration/AddPublishersPermissionsUpgradePluginTest.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright (C) 2026 eXo Platform SAS.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.exoplatform.migration;
+
+import org.exoplatform.commons.api.settings.SettingValue;
+import org.exoplatform.commons.upgrade.UpgradePluginExecutionContext;
+import org.exoplatform.container.xml.InitParams;
+import org.exoplatform.commons.persistence.impl.EntityManagerService;
+import org.exoplatform.commons.api.settings.SettingService;
+import org.exoplatform.container.xml.ValueParam;
+import org.exoplatform.services.jcr.RepositoryService;
+import org.exoplatform.services.jcr.access.PermissionType;
+import org.exoplatform.services.jcr.config.RepositoryEntry;
+import org.exoplatform.services.jcr.core.ExtendedNode;
+import org.exoplatform.services.jcr.core.ManageableRepository;
+import org.exoplatform.services.jcr.ext.app.SessionProviderService;
+import org.exoplatform.services.jcr.ext.common.SessionProvider;
+import org.exoplatform.services.jcr.ext.hierarchy.NodeHierarchyCreator;
+import org.exoplatform.social.core.space.spi.SpaceService;
+import org.exoplatform.social.core.space.model.Space;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import javax.jcr.NodeIterator;
+import javax.jcr.Session;
+import javax.jcr.Workspace;
+import javax.jcr.nodetype.NodeType;
+
+import java.util.Collections;
+
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class AddPublishersPermissionsUpgradePluginTest {
+
+  @Mock
+  private SpaceService                          spaceService;
+
+  @Mock
+  private SessionProviderService                sessionProviderService;
+
+  @Mock
+  private RepositoryService                     repositoryService;
+
+  @Mock
+  private EntityManagerService                  entityManagerService;
+
+  @Mock
+  private SettingService                        settingService;
+
+  @Mock
+  private NodeHierarchyCreator                  nodeHierarchyCreator;
+
+  @Mock
+  private ManageableRepository                  repository;
+
+  @Mock
+  private RepositoryEntry                       repositoryEntry;
+
+  @Mock
+  private ExtendedNode                          extendedNode;
+
+  private AddPublishersPermissionsUpgradePlugin addPublishersPermissionsUpgradePlugin;
+
+  @Before
+  public void setUp() {
+    InitParams initParams = new InitParams();
+
+    ValueParam valueParam = new ValueParam();
+    valueParam.setName("product.group.id");
+    valueParam.setValue("org.exoplatform.platform");
+    initParams.addParameter(valueParam);
+    addPublishersPermissionsUpgradePlugin = spy(new AddPublishersPermissionsUpgradePlugin(initParams,
+                                                                                      spaceService,
+                                                                                      sessionProviderService,
+                                                                                      repositoryService,
+                                                                                      entityManagerService,
+                                                                                      nodeHierarchyCreator,
+                                                                                      settingService));
+  }
+
+  @Test
+  public void testProcessUpgrade_successfulMigration() throws Exception {
+    // Mock space
+    Space space = new Space();
+    space.setId("1");
+    space.setGroupId("/platform/users");
+    space.setPrettyName("TestSpace");
+    when(spaceService.getSpaceById("1")).thenReturn(space);
+
+    lenient().when(repositoryService.getCurrentRepository()).thenReturn(repository);
+    SessionProvider sessionProvider = mock(SessionProvider.class);
+    when(sessionProviderService.getSystemSessionProvider(any())).thenReturn(sessionProvider);
+    Session session = mock(Session.class);
+    when(sessionProvider.getSession(anyString(), any(ManageableRepository.class))).thenReturn(session);
+    Workspace workspace = mock(Workspace.class);
+    lenient().when(session.getWorkspace()).thenReturn(workspace);
+
+    when(nodeHierarchyCreator.getJcrPath(AddPublishersPermissionsUpgradePlugin.GROUPS_PATH_ALIAS))
+            .thenReturn("/Groups/");
+    when(session.itemExists(anyString())).thenReturn(true);
+    when(session.getItem(anyString())).thenReturn(extendedNode);
+
+    NodeType nodeType = mock(NodeType.class);
+    when(nodeType.getName()).thenReturn("nt:file");
+    when(extendedNode.getPrimaryNodeType()).thenReturn(nodeType);
+    NodeIterator nodeIterator = mock(NodeIterator.class);
+    when(nodeIterator.hasNext()).thenReturn(true, false);
+    when(nodeIterator.nextNode()).thenReturn(extendedNode);
+    when(extendedNode.getNodes()).thenReturn(nodeIterator);
+
+    doReturn(Collections.singletonList(1L)).when(addPublishersPermissionsUpgradePlugin).getRedactionalSpaces();
+    // Run the processUpgrade method
+    addPublishersPermissionsUpgradePlugin.processUpgrade("1.0", "2.0");
+
+    verify(extendedNode).setPermission("publisher:/platform/users", PermissionType.ALL);
+    verify(extendedNode).save();
+    verify(session).save();
+  }
+
+  @Test
+  public void testProcessUpgrade_noSpaces() {
+    // No spaces to migrate
+    lenient().doReturn(Collections.emptyList()).when(addPublishersPermissionsUpgradePlugin).getRedactionalSpaces();
+    // Run the processUpgrade method
+    addPublishersPermissionsUpgradePlugin.processUpgrade("1.0", "2.0");
+
+    verify(spaceService, never()).getSpaceById(anyString());
+  }
+
+  @Test
+  public void shouldProceedToUpgrade() {
+    SettingValue settingValue = mock(SettingValue.class);
+    UpgradePluginExecutionContext context = new UpgradePluginExecutionContext("0.9", 1);
+    when(settingService.get(any(), any(), anyString())).thenReturn(null);
+    addPublishersPermissionsUpgradePlugin.shouldProceedToUpgrade("0.9", "1.0", context);
+    verify(settingService, times(1)).set(any(), any(), anyString(), any());
+    reset(settingService);
+    when(settingService.get(any(), any(), anyString())).thenReturn(settingValue);
+    context.setVersion("1.2");
+    addPublishersPermissionsUpgradePlugin.shouldProceedToUpgrade("1.2", "1.0", context);
+    verify(settingService, times(0)).set(any(), any(), anyString(), any());
+  }
+}

--- a/data-upgrade-packaging/pom.xml
+++ b/data-upgrade-packaging/pom.xml
@@ -72,6 +72,10 @@
       <groupId>${project.groupId}</groupId>
       <artifactId>data-upgrade-hide-default-folders</artifactId>
     </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>data-upgrade-documents-permissions</artifactId>
+    </dependency>
   </dependencies>
   <build>
     <finalName>data-upgrade-addon</finalName>

--- a/pom.xml
+++ b/pom.xml
@@ -32,12 +32,14 @@
     <module>data-upgrade-packaging</module>
     <module>data-upgrade-processes-documents</module>
     <module>data-upgrade-hide-default-folders</module>
+    <module>data-upgrade-documents-permissions</module>
   </modules>
   <properties>
     <!-- 3rd party libraries versions -->
     <addon.exo.ecms.version>7.2.x-maintenance-SNAPSHOT</addon.exo.ecms.version>
     <addon.exo.processes.version>7.2.x-maintenance-SNAPSHOT</addon.exo.processes.version>
     <addon.exo.onlyoffice.version>7.2.x-maintenance-SNAPSHOT</addon.exo.onlyoffice.version>
+    <addon.exo.documents.version>7.2.x-maintenance-SNAPSHOT</addon.exo.documents.version>
 
     <!-- Sonar properties -->
     <sonar.organization>exoplatform</sonar.organization>
@@ -66,6 +68,14 @@
         <artifactId>exo-onlyoffice-editor-parent</artifactId>
         <groupId>org.exoplatform.addons.onlyoffice</groupId>
         <version>${addon.exo.onlyoffice.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+
+      <dependency>
+        <groupId>org.exoplatform.documents</groupId>
+        <artifactId>documents-parent</artifactId>
+        <version>${addon.exo.documents.version}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -118,6 +128,11 @@
       <dependency>
         <groupId>${project.groupId}</groupId>
         <artifactId>data-upgrade-hide-default-folders</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>${project.groupId}</groupId>
+        <artifactId>data-upgrade-documents-permissions</artifactId>
         <version>${project.version}</version>
       </dependency>
       <dependency>


### PR DESCRIPTION
Prior to this change, old redaction spaces did not automatically receive publisher permissions. This change will Introduce a new AddPublishersPermissionsUpgradePlugin to automatically add these permissions to all redactional spaces by processing in chunks to ensure scalability.
