### PR TITLE
Fix: update the Hide Default Personal Folders upgrade plugin to include the Public folder - EXO-87032 

### DIFF
--- a/data-upgrade-hide-default-folders/src/main/java/org/exoplatform/jcr/upgrade/HideDefaultFoldersUpgradePlugin.java
+++ b/data-upgrade-hide-default-folders/src/main/java/org/exoplatform/jcr/upgrade/HideDefaultFoldersUpgradePlugin.java
@@ -18,6 +18,7 @@ package org.exoplatform.jcr.upgrade;
 
 import javax.jcr.Node;
 import javax.jcr.NodeIterator;
+import javax.jcr.RepositoryException;
 import javax.jcr.Session;
 import javax.jcr.query.Query;
 import javax.jcr.query.QueryResult;
@@ -32,6 +33,7 @@ import org.exoplatform.container.PortalContainer;
 import org.exoplatform.container.component.RequestLifeCycle;
 import org.exoplatform.container.xml.InitParams;
 import org.exoplatform.services.jcr.RepositoryService;
+import org.exoplatform.services.jcr.core.ExtendedNode;
 import org.exoplatform.services.jcr.ext.app.SessionProviderService;
 import org.exoplatform.services.jcr.ext.common.SessionProvider;
 import org.exoplatform.services.log.ExoLogger;
@@ -45,9 +47,9 @@ public class HideDefaultFoldersUpgradePlugin extends UpgradeProductPlugin {
 
   private static final Log             LOG                 = ExoLogger.getLogger(HideDefaultFoldersUpgradePlugin.class.getName());
 
-  private static final String          PLUGIN_NAME         = "HideDefaultFoldersUpgrade";
+  private static final String          PLUGIN_NAME         = "HideDefaultFoldersUpgradePlugin";
 
-  private static final String          PLUGIN_EXECUTED_KEY = "hideDefaultFoldersUpgradeExecuted";
+  private static final String          PLUGIN_EXECUTED_KEY = String.format("%sExecuted", PLUGIN_NAME);
 
   private final RepositoryService      repositoryService;
 
@@ -108,8 +110,9 @@ public class HideDefaultFoldersUpgradePlugin extends UpgradeProductPlugin {
                          """
                              SELECT * FROM nt:base
                              WHERE jcr:path LIKE '%/Private/%'
-                             AND  (jcr:primaryType ='nt:unstructured' OR jcr:primaryType ='nt:folder')
-                             AND (jcr:mixinTypes LIKE 'exo:musicFolder' OR jcr:mixinTypes LIKE 'exo:pictureFolder' OR jcr:mixinTypes LIKE 'exo:videoFolder' OR jcr:mixinTypes LIKE 'exo:favoriteFolder')AND NOT jcr:mixinTypes LIKE 'exo:hiddenable'
+                             AND  (jcr:primaryType ='nt:unstructured' OR jcr:primaryType ='nt:folder' OR jcr:primaryType ='exo:symlink')
+                             AND (jcr:mixinTypes LIKE 'exo:musicFolder' OR jcr:mixinTypes LIKE 'exo:pictureFolder' OR jcr:mixinTypes LIKE 'exo:videoFolder' OR jcr:mixinTypes LIKE 'exo:favoriteFolder' OR (jcr:mixinTypes LIKE 'mix:documentsView' AND exo:name LIKE 'Public' ))
+                             AND NOT jcr:mixinTypes LIKE 'exo:hiddenable'
                              """;
 
       Query jcrQuery = users.getSession().getWorkspace().getQueryManager().createQuery(queryString, Query.SQL);
@@ -119,8 +122,12 @@ public class HideDefaultFoldersUpgradePlugin extends UpgradeProductPlugin {
       LOG.info("Total number of folders: {}", totalFoldersCount);
       while (nodeIterator.hasNext()) {
         Node node = nodeIterator.nextNode();
-        node.addMixin("exo:hiddenable");
-        node.save();
+        if (isPublicNode(node)) {
+          hidePublicNode(node);
+        } else {
+          node.addMixin("exo:hiddenable");
+          node.save();
+        }
         hidedFoldersCount++;
         if (hidedFoldersCount % 1000 == 0) {
           LOG.info("{} folders hidden ", hidedFoldersCount);
@@ -139,5 +146,20 @@ public class HideDefaultFoldersUpgradePlugin extends UpgradeProductPlugin {
       }
       RequestLifeCycle.end();
     }
+  }
+
+  private boolean isPublicNode(Node node) {
+    try {
+      return node.getName().equals("Public");
+    } catch (Exception exception) {
+      return false;
+    }
+  }
+
+  private void hidePublicNode(Node node) throws RepositoryException {
+    ExtendedNode extNode = (ExtendedNode) node;
+    extNode.removePermission("any");
+    extNode.addMixin("exo:hiddenable");
+    extNode.save();
   }
 }

--- a/data-upgrade-hide-default-folders/src/main/java/org/exoplatform/jcr/upgrade/HideDefaultFoldersUpgradePlugin.java
+++ b/data-upgrade-hide-default-folders/src/main/java/org/exoplatform/jcr/upgrade/HideDefaultFoldersUpgradePlugin.java
@@ -47,7 +47,7 @@ public class HideDefaultFoldersUpgradePlugin extends UpgradeProductPlugin {
 
   private static final Log             LOG                 = ExoLogger.getLogger(HideDefaultFoldersUpgradePlugin.class.getName());
 
-  private static final String          PLUGIN_NAME         = "HideDefaultFoldersUpgradePlugin";
+  private static final String          PLUGIN_NAME         = "HidePersonalDriveDefaultFoldersUpgrade";
 
   private static final String          PLUGIN_EXECUTED_KEY = String.format("%sExecuted", PLUGIN_NAME);
 
@@ -111,7 +111,7 @@ public class HideDefaultFoldersUpgradePlugin extends UpgradeProductPlugin {
                              SELECT * FROM nt:base
                              WHERE jcr:path LIKE '%/Private/%'
                              AND  (jcr:primaryType ='nt:unstructured' OR jcr:primaryType ='nt:folder' OR jcr:primaryType ='exo:symlink')
-                             AND (jcr:mixinTypes LIKE 'exo:musicFolder' OR jcr:mixinTypes LIKE 'exo:pictureFolder' OR jcr:mixinTypes LIKE 'exo:videoFolder' OR jcr:mixinTypes LIKE 'exo:favoriteFolder' OR (jcr:mixinTypes LIKE 'mix:documentsView' AND exo:name LIKE 'Public' ))
+                             AND (jcr:mixinTypes LIKE 'exo:musicFolder' OR jcr:mixinTypes LIKE 'exo:pictureFolder' OR jcr:mixinTypes LIKE 'exo:videoFolder' OR jcr:mixinTypes LIKE 'exo:favoriteFolder' OR exo:name LIKE 'Public')
                              AND NOT jcr:mixinTypes LIKE 'exo:hiddenable'
                              """;
 

--- a/data-upgrade-hide-default-folders/src/main/resources/conf/portal/configuration.xml
+++ b/data-upgrade-hide-default-folders/src/main/resources/conf/portal/configuration.xml
@@ -22,7 +22,7 @@
   <external-component-plugins>
     <target-component>org.exoplatform.commons.upgrade.UpgradeProductService</target-component>
     <component-plugin  profiles="ecms">
-      <name>HideUsersPersonalDriveDefaultFolders</name>
+      <name>HideDefaultFoldersUpgradePlugin</name>
       <set-method>addUpgradePlugin</set-method>
       <type>org.exoplatform.jcr.upgrade.HideDefaultFoldersUpgradePlugin</type>
       <description>Hide user default folders</description>

--- a/data-upgrade-hide-default-folders/src/main/resources/conf/portal/configuration.xml
+++ b/data-upgrade-hide-default-folders/src/main/resources/conf/portal/configuration.xml
@@ -22,7 +22,7 @@
   <external-component-plugins>
     <target-component>org.exoplatform.commons.upgrade.UpgradeProductService</target-component>
     <component-plugin  profiles="ecms">
-      <name>HideUsersDefaultFolders</name>
+      <name>HideUsersPersonalDriveDefaultFolders</name>
       <set-method>addUpgradePlugin</set-method>
       <type>org.exoplatform.jcr.upgrade.HideDefaultFoldersUpgradePlugin</type>
       <description>Hide user default folders</description>
@@ -50,7 +50,7 @@
         <value-param>
           <name>plugin.upgrade.target.version</name>
           <description>Target version of the plugin</description>
-          <value>7.1.0</value>
+          <value>7.2.0</value>
         </value-param>
       </init-params>
     </component-plugin>


### PR DESCRIPTION
Prior to this change, the HideDefaultFoldersUpgradePlugin was executed in version 7.1.0 to hide the default personal drive folders (Music, Favorites, etc.). This update extends the plugin to also hide the Public folder and remove the any permission from it. The plugin will be re-executed in version 7.2 to apply these changes to existing installations.