### PR TITLE
feat: force to remove anonymous permissions for space documents - EXO-87896

### DIFF
--- a/data-upgrade-documents-permissions/src/main/java/org/exoplatform/upgrade/AddPublishersPermissionsUpgradePlugin.java
+++ b/data-upgrade-documents-permissions/src/main/java/org/exoplatform/upgrade/AddPublishersPermissionsUpgradePlugin.java
@@ -14,7 +14,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-package org.exoplatform.migration;
+package org.exoplatform.upgrade;
 
 import io.meeds.social.space.constant.SpaceMembershipStatus;
 import jakarta.persistence.TypedQuery;

--- a/data-upgrade-documents-permissions/src/main/java/org/exoplatform/upgrade/RemoveAnyPermissionUpgradePlugin.java
+++ b/data-upgrade-documents-permissions/src/main/java/org/exoplatform/upgrade/RemoveAnyPermissionUpgradePlugin.java
@@ -1,0 +1,195 @@
+/**
+ * Copyright (C) 2026 eXo Platform SAS.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.exoplatform.upgrade;
+
+import java.util.Collections;
+
+import javax.jcr.NodeIterator;
+import javax.jcr.RepositoryException;
+import javax.jcr.Session;
+import javax.jcr.query.Query;
+import javax.jcr.query.QueryManager;
+
+import org.exoplatform.commons.upgrade.UpgradePluginException;
+import org.exoplatform.commons.upgrade.UpgradeProductPlugin;
+import org.exoplatform.container.xml.InitParams;
+import org.exoplatform.services.jcr.RepositoryService;
+import org.exoplatform.services.jcr.access.AccessControlEntry;
+import org.exoplatform.services.jcr.core.ExtendedNode;
+import org.exoplatform.services.jcr.core.ExtendedSession;
+import org.exoplatform.services.jcr.core.ManageableRepository;
+import org.exoplatform.services.security.IdentityConstants;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class RemoveAnyPermissionUpgradePlugin extends UpgradeProductPlugin {
+
+  private static final long   ANONYMOUS_SESSION_TIMEOUT = 3600000l;
+
+  private static final int    LIMIT_PER_SESSION         = 100;
+
+  private static final String ANY_SPACES_JCR_SQL_QUERY  =
+                                                       "SELECT * FROM exo:privilegeable WHERE jcr:path LIKE '/Groups/spaces/%'";
+
+  private RepositoryService   repositoryService;
+
+  public RemoveAnyPermissionUpgradePlugin(InitParams initParams,
+                                          RepositoryService repositoryService) {
+    super(initParams);
+    this.repositoryService = repositoryService;
+  }
+
+  @Override
+  public void processUpgrade(String oldVersion, String newVersion) throws UpgradePluginException {
+    upgradePathType(ANY_SPACES_JCR_SQL_QUERY, "spaces");
+  }
+
+  private void upgradePathType(String jcrSqlQuery, String pathType) {
+    log.info("START:: {} anonymously accessible documents", pathType);
+    UpgradeReport upgradeReport = new UpgradeReport();
+    try {
+      boolean hasMore = true;
+      do {
+        hasMore = upgradeChunk(jcrSqlQuery, LIMIT_PER_SESSION, upgradeReport);
+      } while (hasMore);
+    } catch (Exception e) {
+      log.error("{} anonymously accessible documents migration interrupted, current status: {}", pathType, upgradeReport, e);
+    }
+    if (upgradeReport.errorCount > 0
+        || canAnonymouslyAccess(jcrSqlQuery, pathType)) {
+      throw new UpgradePluginException("Some %s documents wasn't upgraded. It will be re-attempted next startup. Report: %s".formatted(pathType,
+                                                                                                                                       upgradeReport));
+    } else {
+      log.info("END:: {} anonymously accessible documents migration: {}", pathType, upgradeReport);
+    }
+  }
+
+  private boolean upgradeChunk(String sqlQuery, int limit, UpgradeReport upgradeReport) throws RepositoryException {
+    ManageableRepository repository = repositoryService.getCurrentRepository();
+    Session systemSession = getSystemSession(repository);
+    Session anonymousUserSession = getAnonymousSession(repository);
+    int count = 0;
+    try {
+      QueryManager queryManager = anonymousUserSession.getWorkspace().getQueryManager();
+      Query query = queryManager.createQuery(sqlQuery, Query.SQL);
+      NodeIterator nodesIterator = query.execute().getNodes();
+      while (nodesIterator.hasNext() && count < limit) {
+        upgradeNextAnonymousNode(nodesIterator,
+                                 systemSession,
+                                 upgradeReport);
+        count++;
+      }
+      return count == limit;
+    } finally {
+      upgradeReport.incrementTotalCount(count);
+      log.info("PROGRESS:: anonymously accessible documents migration: {}", upgradeReport);
+      anonymousUserSession.logout();
+      systemSession.logout();
+    }
+  }
+
+  private void upgradeNextAnonymousNode(NodeIterator anonymousNodesIterator,
+                                        Session systemSession,
+                                        UpgradeReport upgradeReport) {
+    String path = null;
+    try {
+      path = anonymousNodesIterator.nextNode().getPath();
+      ExtendedNode node = (ExtendedNode) systemSession.getItem(path);
+      if (hasAnyPermissions(node)) {
+        node.removePermission(IdentityConstants.ANY);
+        node.save();
+      }
+      upgradeReport.incrementProcessedCount();
+    } catch (Exception e) {
+      upgradeReport.incrementErrorCount();
+      log.warn("Error while deleting 'any' permission from Node with path '{}'. Continue the upgrade", path, e);
+    }
+  }
+
+  private boolean canAnonymouslyAccess(String sqlQuery, String pathType) {
+    Session anonymousUserSession = null;
+    try {
+      ManageableRepository repository = repositoryService.getCurrentRepository();
+      anonymousUserSession = getAnonymousSession(repository);
+      QueryManager queryManager = anonymousUserSession.getWorkspace().getQueryManager();
+      Query query = queryManager.createQuery(sqlQuery, Query.SQL);
+      NodeIterator nodesIterator = query.execute().getNodes();
+      return nodesIterator.hasNext();
+    } catch (Exception e) {
+      log.warn("{} anonymously accessible documents migration check error. Consider it as not fully upgraded", pathType, e);
+      return true;
+    } finally {
+      if (anonymousUserSession != null) {
+        anonymousUserSession.logout();
+      }
+    }
+  }
+
+  private Session getAnonymousSession(ManageableRepository repository) throws RepositoryException {
+    ExtendedSession dynamicSession = (ExtendedSession) repository.getDynamicSession(
+                                                                                    repository.getConfiguration()
+                                                                                              .getDefaultWorkspaceName(),
+                                                                                    Collections.emptyList());
+    dynamicSession.setTimeout(ANONYMOUS_SESSION_TIMEOUT);
+    return dynamicSession;
+  }
+
+  private Session getSystemSession(ManageableRepository repository) throws RepositoryException {
+    return repository.getSystemSession(repository.getConfiguration().getDefaultWorkspaceName());
+  }
+
+  private boolean hasAnyPermissions(ExtendedNode node) throws RepositoryException {
+    return node.getACL()
+               .getPermissionEntries()
+               .stream()
+               .map(AccessControlEntry::getIdentity)
+               .anyMatch(IdentityConstants.ANY::equals);
+  }
+
+  public static class UpgradeReport {
+
+    private int  totalCount     = 0;
+
+    private int  processedCount = 0;
+
+    private int  errorCount     = 0;
+
+    private long startupTime    = System.currentTimeMillis();
+
+    public void incrementTotalCount(int count) {
+      this.totalCount += count;
+    }
+
+    public void incrementProcessedCount() {
+      this.processedCount++;
+    }
+
+    public void incrementErrorCount() {
+      this.errorCount++;
+    }
+
+    @Override
+    public String toString() {
+      return "Total: %s, Processed: %s, Errors: %s within %s ms".formatted(totalCount,
+                                                                           processedCount,
+                                                                           errorCount,
+                                                                           System.currentTimeMillis() - startupTime);
+    }
+  }
+
+}

--- a/data-upgrade-documents-permissions/src/main/resources/conf/portal/configuration.xml
+++ b/data-upgrade-documents-permissions/src/main/resources/conf/portal/configuration.xml
@@ -16,7 +16,7 @@
     <component-plugin>
       <name>AddPublishersPermissionsUpgradePlugin</name>
       <set-method>addUpgradePlugin</set-method>
-      <type>org.exoplatform.migration.AddPublishersPermissionsUpgradePlugin</type>
+      <type>org.exoplatform.upgrade.AddPublishersPermissionsUpgradePlugin</type>
       <description>Adds permissions to existing publisher spaces</description>
       <init-params>
         <value-param>
@@ -28,6 +28,34 @@
           <name>plugin.execution.order</name>
           <description>The plugin execution order</description>
           <value>10</value>
+        </value-param>
+        <value-param>
+          <name>plugin.upgrade.execute.once</name>
+          <description>The plugin must be executed only once</description>
+          <value>true</value>
+        </value-param>
+        <value-param>
+          <name>plugin.upgrade.async.execution</name>
+          <description>The plugin will be executed in an asynchronous mode</description>
+          <value>true</value>
+        </value-param>
+      </init-params>
+    </component-plugin>
+    <component-plugin>
+      <name>RemoveAnyPermissionUpgradePlugin</name>
+      <set-method>addUpgradePlugin</set-method>
+      <type>org.exoplatform.upgrade.RemoveAnyPermissionUpgradePlugin</type>
+      <description>Remove Any Permissions from spaces and users</description>
+      <init-params>
+        <value-param>
+          <name>product.group.id</name>
+          <description>The groupId of the product</description>
+          <value>org.exoplatform.platform</value>
+        </value-param>
+        <value-param>
+          <name>plugin.execution.order</name>
+          <description>The plugin execution order</description>
+          <value>20</value>
         </value-param>
         <value-param>
           <name>plugin.upgrade.execute.once</name>

--- a/data-upgrade-documents-permissions/src/test/java/org/exoplatform/upgrade/AddPublishersPermissionsUpgradePluginTest.java
+++ b/data-upgrade-documents-permissions/src/test/java/org/exoplatform/upgrade/AddPublishersPermissionsUpgradePluginTest.java
@@ -14,7 +14,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-package org.exoplatform.migration;
+package org.exoplatform.upgrade;
 
 import static org.junit.Assert.assertThrows;
 import static org.mockito.Mockito.*;

--- a/data-upgrade-documents-permissions/src/test/java/org/exoplatform/upgrade/RemoveAnyPermissionUpgradePluginTest.java
+++ b/data-upgrade-documents-permissions/src/test/java/org/exoplatform/upgrade/RemoveAnyPermissionUpgradePluginTest.java
@@ -1,0 +1,176 @@
+/**
+ * Copyright (C) 2026 eXo Platform SAS.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.exoplatform.upgrade;
+
+import static org.junit.Assert.assertThrows;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Collections;
+
+import javax.jcr.Node;
+import javax.jcr.NodeIterator;
+import javax.jcr.Session;
+import javax.jcr.Workspace;
+import javax.jcr.query.Query;
+import javax.jcr.query.QueryManager;
+import javax.jcr.query.QueryResult;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import org.exoplatform.container.xml.InitParams;
+import org.exoplatform.services.jcr.RepositoryService;
+import org.exoplatform.services.jcr.access.AccessControlEntry;
+import org.exoplatform.services.jcr.access.AccessControlList;
+import org.exoplatform.services.jcr.config.RepositoryEntry;
+import org.exoplatform.services.jcr.core.ExtendedNode;
+import org.exoplatform.services.jcr.core.ExtendedSession;
+import org.exoplatform.services.jcr.core.ManageableRepository;
+import org.exoplatform.services.security.IdentityConstants;
+
+import lombok.SneakyThrows;
+
+@RunWith(MockitoJUnitRunner.class)
+public class RemoveAnyPermissionUpgradePluginTest {
+
+  @Mock
+  private RepositoryService                repositoryService;
+
+  @Mock
+  private ManageableRepository             repository;
+
+  @Mock
+  private RepositoryEntry                  repositoryEntry;
+
+  @Mock
+  private Session                          systemSession;
+
+  @Mock
+  private ExtendedSession                  anonymousSession;
+
+  @Mock
+  private Workspace                        workspace;
+
+  @Mock
+  private QueryManager                     queryManager;
+
+  @Mock
+  private Query                            query;
+
+  @Mock
+  private QueryResult                      queryResult;
+
+  @Mock
+  private NodeIterator                     nodeIterator;
+
+  private RemoveAnyPermissionUpgradePlugin plugin;
+
+  @Before
+  @SneakyThrows
+  public void setUp() {
+    plugin = spy(new RemoveAnyPermissionUpgradePlugin(new InitParams(), repositoryService));
+
+    when(repositoryService.getCurrentRepository()).thenReturn(repository);
+    when(repository.getSystemSession(anyString())).thenReturn(systemSession);
+    when(repository.getDynamicSession(anyString(), anyList())).thenReturn(anonymousSession);
+    when(repository.getConfiguration()).thenReturn(repositoryEntry);
+    when(repositoryEntry.getDefaultWorkspaceName()).thenReturn("test");
+
+    when(anonymousSession.getWorkspace()).thenReturn(workspace);
+    when(workspace.getQueryManager()).thenReturn(queryManager);
+    when(queryManager.createQuery(anyString(), eq(Query.SQL))).thenReturn(query);
+    when(query.execute()).thenReturn(queryResult);
+    when(queryResult.getNodes()).thenReturn(nodeIterator);
+  }
+
+  @Test
+  @SneakyThrows
+  public void testProcessUpgradeSuccess() {
+    ExtendedNode node = mockNode("/Users/john/doc1", true);
+
+    when(nodeIterator.hasNext()).thenReturn(true)
+                                .thenReturn(false)
+                                .thenReturn(false)
+                                .thenReturn(false);
+
+    plugin.processUpgrade("1.0", "2.0");
+
+    verify(node).removePermission(IdentityConstants.ANY);
+    verify(node).save();
+  }
+
+  @Test
+  @SneakyThrows
+  public void testSkipNodeWithoutAnyPermission() {
+    ExtendedNode node = mockNode("/Users/john/doc1", false);
+
+    when(nodeIterator.hasNext()).thenReturn(true)
+                                .thenReturn(false)
+                                .thenReturn(false)
+                                .thenReturn(false);
+
+    plugin.processUpgrade("1.0", "2.0");
+
+    verify(node, never()).removePermission(anyString());
+    verify(node, never()).save();
+  }
+
+  @Test
+  @SneakyThrows
+  public void testFailsWhenAnonymousAccessRemains() {
+    when(nodeIterator.hasNext()).thenReturn(false)
+                                .thenReturn(true);
+
+    assertThrows(Exception.class,
+                 () -> plugin.processUpgrade("1.0", "2.0"));
+  }
+
+  @SneakyThrows
+  private ExtendedNode mockNode(String path, boolean anyPermission) {
+    Node anonymousNode = mock(Node.class);
+    when(anonymousNode.getPath()).thenReturn(path);
+
+    when(nodeIterator.nextNode()).thenReturn(anonymousNode);
+
+    ExtendedNode node = mock(ExtendedNode.class);
+    when(systemSession.getItem(path)).thenReturn(node);
+
+    AccessControlList acl = mock(AccessControlList.class);
+
+    if (anyPermission) {
+      AccessControlEntry ace = mock(AccessControlEntry.class);
+      when(ace.getIdentity()).thenReturn(IdentityConstants.ANY);
+      when(acl.getPermissionEntries()).thenReturn(Collections.singletonList(ace));
+    } else {
+      when(acl.getPermissionEntries()).thenReturn(Collections.emptyList());
+    }
+
+    when(node.getACL()).thenReturn(acl);
+
+    return node;
+  }
+}


### PR DESCRIPTION
- remove anonymous permissions from documents under /Groups/spaces
- process nodes in chunks to support large repositories
- retry upgrade on startup if migration is incomplete
- verify that no anonymously accessible documents remain after migration