### PR TITLE
fix: Fix java.security.AccessControlException when executing HideDefaultFoldersUpgradePlugin - EXO-88230

### DIFF
--- a/data-upgrade-hide-default-folders/src/main/java/org/exoplatform/jcr/upgrade/HideDefaultFoldersUpgradePlugin.java
+++ b/data-upgrade-hide-default-folders/src/main/java/org/exoplatform/jcr/upgrade/HideDefaultFoldersUpgradePlugin.java
@@ -108,10 +108,10 @@ public class HideDefaultFoldersUpgradePlugin extends UpgradeProductPlugin {
       Node users = (Node) session.getItem("/Users");
       String queryString =
                          """
-                             SELECT * FROM nt:base
+                             SELECT * FROM exo:privilegeable
                              WHERE jcr:path LIKE '%/Private/%'
                              AND  (jcr:primaryType ='nt:unstructured' OR jcr:primaryType ='nt:folder' OR jcr:primaryType ='exo:symlink')
-                             AND (jcr:mixinTypes LIKE 'exo:musicFolder' OR jcr:mixinTypes LIKE 'exo:pictureFolder' OR jcr:mixinTypes LIKE 'exo:videoFolder' OR jcr:mixinTypes LIKE 'exo:favoriteFolder' OR exo:name LIKE 'Public')
+                             AND (jcr:mixinTypes LIKE 'exo:musicFolder' OR jcr:mixinTypes LIKE 'exo:pictureFolder' OR jcr:mixinTypes LIKE 'exo:videoFolder' OR jcr:mixinTypes LIKE 'exo:favoriteFolder' OR exo:name LIKE 'Public' OR exo:name LIKE 'public')
                              AND NOT jcr:mixinTypes LIKE 'exo:hiddenable'
                              """;
 
@@ -150,7 +150,7 @@ public class HideDefaultFoldersUpgradePlugin extends UpgradeProductPlugin {
 
   private boolean isPublicNode(Node node) {
     try {
-      return node.getName().equals("Public");
+      return node.getName().equals("Public") || node.getName().equals("public");
     } catch (Exception exception) {
       return false;
     }


### PR DESCRIPTION
## Description

During the execution of `HideDefaultFoldersUpgradePlugin`, a `java.security.AccessControlException` was thrown with the message **"Node is not exo:privilegeable"**.

### Root cause

The JCR query used `SELECT * FROM nt:base`, which returns **all nodes** in the user private folder, including nodes that do **not** have the `exo:privilegeable` mixin. When `hidePublicNode()` subsequently calls `node.removePermission()` on such a node, JCR throws `AccessControlException` because permission management requires the node to implement `exo:privilegeable`.

Stack trace:
```
java.security.AccessControlException: Node is not exo:privilegeable /Users/.../Private/.../Public
    at org.exoplatform.services.jcr.impl.core.NodeImpl.removePermission(NodeImpl.java:1966)
    at org.exoplatform.jcr.upgrade.HideDefaultFoldersUpgradePlugin.hidePublicNode(HideDefaultFoldersUpgradePlugin.java:161)
    at org.exoplatform.jcr.upgrade.HideDefaultFoldersUpgradePlugin.processUpgrade(HideDefaultFoldersUpgradePlugin.java:126)
```

### Fix

1. **JCR query type narrowed**: Changed `SELECT * FROM nt:base` to `SELECT * FROM exo:privilegeable`. This guarantees that only nodes carrying the `exo:privilegeable` mixin are returned, so `removePermission()` can always be called safely on the results.

## Test plan

- [ ] Run the `HideDefaultFoldersUpgradePlugin` on a platform instance and verify no `AccessControlException` is thrown
- [ ] Verify that the default folders (music, pictures, videos, favorites, Public/public) are correctly hidden after the upgrade

:robot: Generated with [Claude Code](https://claude.com/claude-code)